### PR TITLE
Builder API with new controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,22 @@ in-house reporter though, we're very open to feedback on how this can be improve
 
 More examples and details can be found in the [wiki](https://github.com/uber/RxDogTag/wiki)
 
-## Custom handlers
+## Configuration
+
+RxDogTag has an alternative `RxDogTag.builder()` API to facilitate added configuration, such as annotation
+control, stacktrace element location, and more.
+
+### Custom handlers
 
 In the event of custom observers that possibly decorate other observer types, this information can
 be passed to RxDogTag via the `ObserverHandler` interface. This interface can be used to unwrap 
 these custom observers to reveal their delegates and their potential behavior. Install these via
-the `RxDogTag.install()` overloads that accept handlers.
+the `RxDogTag.Builder#addObserverHandlers(...)` overloads that accept handlers.
+
+### Ignored packages
+
+RxDogTag needs to ignore certain packages (such as its own or RxJava's) when inspecting stack traces
+to deduce the subscribe point. You can add other custom ones via `RxDogTag.Builder#addIgnoredPackages(...)`.
 
 ### AutoDispose support
 
@@ -111,7 +121,9 @@ interfaces. Support for this is available via separate `rxdogtag-autodispose` ar
 `AutoDisposeObserverHandler` singleton instance.
 
 ```java
-RxDogTag.install(AutoDisposeObserverHandler.INSTANCE)
+RxDogTag.Builder builder = RxDogTag.builder();
+AutoDisposeObserverHandler.configureWith(builder);
+builder.install();
 ```
 
 [![Maven Central](https://img.shields.io/maven-central/v/com.uber.rxdogtag/rxdogtag-autodispose.svg)](https://mvnrepository.com/artifact/com.uber.rxdogtag/rxdogtag-autodispose)

--- a/rxdogtag-autodispose/src/main/java/com/uber/rxdogtag/autodispose/AutoDisposeConfigurer.java
+++ b/rxdogtag-autodispose/src/main/java/com/uber/rxdogtag/autodispose/AutoDisposeConfigurer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2019. Uber Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.uber.rxdogtag.autodispose;
+
+import com.uber.autodispose.AutoDispose;
+import com.uber.rxdogtag.ObserverHandler;
+import com.uber.rxdogtag.RxDogTag;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Configures an {@link RxDogTag.Builder} with:
+ *
+ * <ul>
+ *   <li>A {@link ObserverHandler} that supports handling AutoDispose's decorating observers to
+ *       retrieve their underlying delegate observers.
+ *   <li>Ignored packages.
+ * </ul>
+ *
+ * <p>Usage: Configure with {@link #configure(RxDogTag.Builder)}.
+ */
+public final class AutoDisposeConfigurer {
+
+  private AutoDisposeConfigurer() {}
+
+  private static final Set<String> IGNORE_PACKAGES =
+      Collections.singleton(
+          // "com.uber.autodispose"
+          AutoDispose.class.getPackage().getName());
+
+  public static void configure(RxDogTag.Builder builder) {
+    builder
+        .addObserverHandlers(AutoDisposeObserverHandler.INSTANCE)
+        .addIgnoredPackages(IGNORE_PACKAGES);
+  }
+}

--- a/rxdogtag-autodispose/src/main/java/com/uber/rxdogtag/autodispose/AutoDisposeObserverHandler.java
+++ b/rxdogtag-autodispose/src/main/java/com/uber/rxdogtag/autodispose/AutoDisposeObserverHandler.java
@@ -15,14 +15,12 @@
  */
 package com.uber.rxdogtag.autodispose;
 
-import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.observers.AutoDisposingCompletableObserver;
 import com.uber.autodispose.observers.AutoDisposingMaybeObserver;
 import com.uber.autodispose.observers.AutoDisposingObserver;
 import com.uber.autodispose.observers.AutoDisposingSingleObserver;
 import com.uber.autodispose.observers.AutoDisposingSubscriber;
 import com.uber.rxdogtag.ObserverHandler;
-import com.uber.rxdogtag.RxDogTag;
 import io.reactivex.Completable;
 import io.reactivex.CompletableObserver;
 import io.reactivex.Flowable;
@@ -32,35 +30,11 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.Single;
 import io.reactivex.SingleObserver;
-import java.util.Collections;
-import java.util.Set;
 import org.reactivestreams.Subscriber;
 
-/**
- * A {@link ObserverHandler} that supports handling AutoDispose's decorating observers to retrieve
- * their underlying delegate observers.
- *
- * <p>Usage: Configure with {@link #configureWith(RxDogTag.Builder)}.
- */
-public class AutoDisposeObserverHandler implements ObserverHandler {
+final class AutoDisposeObserverHandler implements ObserverHandler {
 
-  /**
-   * Configures an {@link RxDogTag.Builder} with AutoDispose observer handler and ignored packages
-   * support.
-   *
-   * @param builder the builder to configure.
-   * @return the same builder for chaining convenience.
-   */
-  public static RxDogTag.Builder configureWith(RxDogTag.Builder builder) {
-    return builder.addObserverHandlers(INSTANCE).addIgnoredPackages(IGNORE_PACKAGES);
-  }
-
-  private static final AutoDisposeObserverHandler INSTANCE = new AutoDisposeObserverHandler();
-
-  private static final Set<String> IGNORE_PACKAGES =
-      Collections.singleton(
-          // "com.uber.autodispose"
-          AutoDispose.class.getPackage().getName());
+  static final AutoDisposeObserverHandler INSTANCE = new AutoDisposeObserverHandler();
 
   private AutoDisposeObserverHandler() {}
 

--- a/rxdogtag-autodispose/src/main/java/com/uber/rxdogtag/autodispose/AutoDisposeObserverHandler.java
+++ b/rxdogtag-autodispose/src/main/java/com/uber/rxdogtag/autodispose/AutoDisposeObserverHandler.java
@@ -32,9 +32,7 @@ import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.Single;
 import io.reactivex.SingleObserver;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Set;
 import org.reactivestreams.Subscriber;
 
@@ -42,12 +40,22 @@ import org.reactivestreams.Subscriber;
  * A {@link ObserverHandler} that supports handling AutoDispose's decorating observers to retrieve
  * their underlying delegate observers.
  *
- * <p>Usage: Add {@link #INSTANCE} to the list of {@link ObserverHandler SubscribeHandlers} in
- * {@link RxDogTag#install(List)}.
+ * <p>Usage: Configure with {@link #configureWith(RxDogTag.Builder)}.
  */
 public class AutoDisposeObserverHandler implements ObserverHandler {
 
-  public static final AutoDisposeObserverHandler INSTANCE = new AutoDisposeObserverHandler();
+  /**
+   * Configures an {@link RxDogTag.Builder} with AutoDispose observer handler and ignored packages
+   * support.
+   *
+   * @param builder the builder to configure.
+   * @return the same builder for chaining convenience.
+   */
+  public static RxDogTag.Builder configureWith(RxDogTag.Builder builder) {
+    return builder.addObserverHandlers(INSTANCE).addIgnoredPackages(IGNORE_PACKAGES);
+  }
+
+  private static final AutoDisposeObserverHandler INSTANCE = new AutoDisposeObserverHandler();
 
   private static final Set<String> IGNORE_PACKAGES =
       Collections.singleton(
@@ -55,11 +63,6 @@ public class AutoDisposeObserverHandler implements ObserverHandler {
           AutoDispose.class.getPackage().getName());
 
   private AutoDisposeObserverHandler() {}
-
-  @Override
-  public Collection<String> ignorablePackagePrefixes() {
-    return IGNORE_PACKAGES;
-  }
 
   @Override
   public Subscriber handle(Flowable flowable, Subscriber subscriber) {
@@ -99,5 +102,10 @@ public class AutoDisposeObserverHandler implements ObserverHandler {
       return ((AutoDisposingCompletableObserver) observer).delegateObserver();
     }
     return observer;
+  }
+
+  @Override
+  public String toString() {
+    return "AutoDisposeObserverHandler";
   }
 }

--- a/rxdogtag-autodispose/src/test/java/com/uber/anotherpackage/AutoDisposeObserverHandlerTest.java
+++ b/rxdogtag-autodispose/src/test/java/com/uber/anotherpackage/AutoDisposeObserverHandlerTest.java
@@ -34,7 +34,6 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
 import io.reactivex.exceptions.OnErrorNotImplementedException;
-import java.util.Collections;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -52,7 +51,7 @@ public class AutoDisposeObserverHandlerTest implements DogTagTest {
 
   @Before
   public void setUp() {
-    RxDogTag.install(Collections.singletonList(AutoDisposeObserverHandler.INSTANCE));
+    AutoDisposeObserverHandler.configureWith(RxDogTag.builder()).install();
   }
 
   @After
@@ -119,10 +118,10 @@ public class AutoDisposeObserverHandlerTest implements DogTagTest {
    * packages to have names kept in order for DogTagObservers to work their magic correctly.
    *
    * <p>In the event that this test fails, please update the proguard configurations with the new
-   * package names. You will see something like this in our global proguard config.
+   * package names. You will see something like this in the bundled proguard config.
    *
    * <pre><code>
-   *   -keepnames class io.reactivex.**
+   *   -keepnames class com.uber.autodispose.**
    * </code></pre>
    *
    * <p>This should be updated with the new package name.

--- a/rxdogtag-autodispose/src/test/java/com/uber/anotherpackage/AutoDisposeObserverHandlerTest.java
+++ b/rxdogtag-autodispose/src/test/java/com/uber/anotherpackage/AutoDisposeObserverHandlerTest.java
@@ -15,10 +15,6 @@
  */
 package com.uber.anotherpackage;
 
-import static com.google.common.truth.Truth.assertThat;
-import static com.uber.anotherpackage.DogTagTestUtil.getPreviousLineNumber;
-import static com.uber.autodispose.AutoDispose.autoDisposable;
-
 import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.CompletableSubscribeProxy;
 import com.uber.autodispose.FlowableSubscribeProxy;
@@ -38,6 +34,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.uber.anotherpackage.DogTagTestUtil.getPreviousLineNumber;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
 
 /**
  * NOTE: These tests are a little odd. There are two conditions for them running correctly because
@@ -105,7 +105,7 @@ public class AutoDisposeObserverHandlerTest implements DogTagTest {
     assertThat(e.getStackTrace()).isEmpty();
     Throwable cause = e.getCause();
     assertThat(cause.getStackTrace()[0].getClassName())
-        .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
+        .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER_DOWN);
     assertThat(cause.getStackTrace()[1].getFileName())
         .isEqualTo(getClass().getSimpleName() + ".java");
     assertThat(cause.getStackTrace()[1].getLineNumber()).isEqualTo(expectedLineNumber);

--- a/rxdogtag-autodispose/src/test/java/com/uber/anotherpackage/AutoDisposeObserverHandlerTest.java
+++ b/rxdogtag-autodispose/src/test/java/com/uber/anotherpackage/AutoDisposeObserverHandlerTest.java
@@ -15,6 +15,10 @@
  */
 package com.uber.anotherpackage;
 
+import static com.google.common.truth.Truth.assertThat;
+import static com.uber.anotherpackage.DogTagTestUtil.getPreviousLineNumber;
+import static com.uber.autodispose.AutoDispose.autoDisposable;
+
 import com.uber.autodispose.AutoDispose;
 import com.uber.autodispose.CompletableSubscribeProxy;
 import com.uber.autodispose.FlowableSubscribeProxy;
@@ -34,10 +38,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import static com.google.common.truth.Truth.assertThat;
-import static com.uber.anotherpackage.DogTagTestUtil.getPreviousLineNumber;
-import static com.uber.autodispose.AutoDispose.autoDisposable;
 
 /**
  * NOTE: These tests are a little odd. There are two conditions for them running correctly because

--- a/rxdogtag-autodispose/src/test/java/com/uber/anotherpackage/AutoDisposeObserverHandlerTest.java
+++ b/rxdogtag-autodispose/src/test/java/com/uber/anotherpackage/AutoDisposeObserverHandlerTest.java
@@ -27,7 +27,7 @@ import com.uber.autodispose.ObservableSubscribeProxy;
 import com.uber.autodispose.ScopeProvider;
 import com.uber.autodispose.SingleSubscribeProxy;
 import com.uber.rxdogtag.RxDogTag;
-import com.uber.rxdogtag.autodispose.AutoDisposeObserverHandler;
+import com.uber.rxdogtag.autodispose.AutoDisposeConfigurer;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Maybe;
@@ -45,13 +45,13 @@ import org.junit.Test;
  * immediately after subscribe (on the next line). 2. it must not be in the com.uber.rxdogtag
  * package because that is filtered out in stacktrace inspection.
  */
-public class AutoDisposeObserverHandlerTest implements DogTagTest {
+public final class AutoDisposeObserverHandlerTest implements DogTagTest {
 
   @Rule public RxErrorsRule errorsRule = new RxErrorsRule();
 
   @Before
   public void setUp() {
-    AutoDisposeObserverHandler.configureWith(RxDogTag.builder()).install();
+    RxDogTag.builder().configureWith(AutoDisposeConfigurer::configure).install();
   }
 
   @After

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagCompletableObserver.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagCompletableObserver.java
@@ -35,25 +35,28 @@ import io.reactivex.observers.LambdaConsumerIntrospection;
 final class DogTagCompletableObserver implements CompletableObserver, LambdaConsumerIntrospection {
 
   private final Throwable t = new Throwable();
+  private final RxDogTag.Configuration config;
   private final CompletableObserver delegate;
 
-  DogTagCompletableObserver(CompletableObserver delegate) {
+  DogTagCompletableObserver(RxDogTag.Configuration config, CompletableObserver delegate) {
+    this.config = config;
     this.delegate = delegate;
   }
 
   @Override
   public void onSubscribe(Disposable d) {
-    guardedDelegateCall(e -> reportError(t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    guardedDelegateCall(
+        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
   }
 
   @Override
   public void onError(Throwable e) {
-    reportError(t, e, null);
+    reportError(config, t, e, null);
   }
 
   @Override
   public void onComplete() {
-    guardedDelegateCall(e -> reportError(t, e, "onComplete"), delegate::onComplete);
+    guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagMaybeObserver.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagMaybeObserver.java
@@ -38,30 +38,34 @@ import io.reactivex.observers.LambdaConsumerIntrospection;
 final class DogTagMaybeObserver<T> implements MaybeObserver<T>, LambdaConsumerIntrospection {
 
   private final Throwable t = new Throwable();
+  private final RxDogTag.Configuration config;
   private final MaybeObserver<T> delegate;
 
-  DogTagMaybeObserver(MaybeObserver<T> delegate) {
+  DogTagMaybeObserver(RxDogTag.Configuration config, MaybeObserver<T> delegate) {
+    this.config = config;
     this.delegate = delegate;
   }
 
   @Override
   public void onSubscribe(Disposable d) {
-    guardedDelegateCall(e -> reportError(t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    guardedDelegateCall(
+        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
   }
 
   @Override
   public void onSuccess(T t) {
-    guardedDelegateCall(e -> reportError(this.t, e, "onSuccess"), () -> delegate.onSuccess(t));
+    guardedDelegateCall(
+        e -> reportError(config, this.t, e, "onSuccess"), () -> delegate.onSuccess(t));
   }
 
   @Override
   public void onError(Throwable e) {
-    reportError(t, e, null);
+    reportError(config, t, e, null);
   }
 
   @Override
   public void onComplete() {
-    guardedDelegateCall(e -> reportError(t, e, "onComplete"), delegate::onComplete);
+    guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagObserver.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagObserver.java
@@ -37,30 +37,33 @@ import io.reactivex.observers.LambdaConsumerIntrospection;
 final class DogTagObserver<T> implements Observer<T>, LambdaConsumerIntrospection {
 
   private final Throwable t = new Throwable();
+  private final RxDogTag.Configuration config;
   private final Observer<T> delegate;
 
-  DogTagObserver(Observer<T> delegate) {
+  DogTagObserver(RxDogTag.Configuration config, Observer<T> delegate) {
+    this.config = config;
     this.delegate = delegate;
   }
 
   @Override
   public void onSubscribe(Disposable d) {
-    guardedDelegateCall(e -> reportError(t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    guardedDelegateCall(
+        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
   }
 
   @Override
   public void onNext(T t) {
-    guardedDelegateCall(e -> reportError(this.t, e, "onNext"), () -> delegate.onNext(t));
+    guardedDelegateCall(e -> reportError(config, this.t, e, "onNext"), () -> delegate.onNext(t));
   }
 
   @Override
   public void onError(Throwable e) {
-    reportError(t, e, null);
+    reportError(config, t, e, null);
   }
 
   @Override
   public void onComplete() {
-    guardedDelegateCall(e -> reportError(t, e, "onComplete"), delegate::onComplete);
+    guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagSingleObserver.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagSingleObserver.java
@@ -37,25 +37,29 @@ import io.reactivex.observers.LambdaConsumerIntrospection;
 final class DogTagSingleObserver<T> implements SingleObserver<T>, LambdaConsumerIntrospection {
 
   private final Throwable t = new Throwable();
+  private final RxDogTag.Configuration config;
   private final SingleObserver<T> delegate;
 
-  DogTagSingleObserver(SingleObserver<T> delegate) {
+  DogTagSingleObserver(RxDogTag.Configuration config, SingleObserver<T> delegate) {
+    this.config = config;
     this.delegate = delegate;
   }
 
   @Override
   public void onSubscribe(Disposable d) {
-    guardedDelegateCall(e -> reportError(t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    guardedDelegateCall(
+        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
   }
 
   @Override
   public void onSuccess(T t) {
-    guardedDelegateCall(e -> reportError(this.t, e, "onSuccess"), () -> delegate.onSuccess(t));
+    guardedDelegateCall(
+        e -> reportError(config, this.t, e, "onSuccess"), () -> delegate.onSuccess(t));
   }
 
   @Override
   public void onError(Throwable e) {
-    reportError(t, e, null);
+    reportError(config, t, e, null);
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagSubscriber.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagSubscriber.java
@@ -43,30 +43,33 @@ import org.reactivestreams.Subscription;
 final class DogTagSubscriber<T> implements FlowableSubscriber<T>, LambdaConsumerIntrospection {
 
   private final Throwable t = new Throwable();
+  private final RxDogTag.Configuration config;
   private final Subscriber<T> delegate;
 
-  DogTagSubscriber(Subscriber<T> delegate) {
+  DogTagSubscriber(RxDogTag.Configuration config, Subscriber<T> delegate) {
+    this.config = config;
     this.delegate = delegate;
   }
 
   @Override
   public void onSubscribe(Subscription s) {
-    guardedDelegateCall(e -> reportError(t, e, "onSubscribe"), () -> delegate.onSubscribe(s));
+    guardedDelegateCall(
+        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(s));
   }
 
   @Override
   public void onNext(T t) {
-    guardedDelegateCall(e -> reportError(this.t, e, "onNext"), () -> delegate.onNext(t));
+    guardedDelegateCall(e -> reportError(config, this.t, e, "onNext"), () -> delegate.onNext(t));
   }
 
   @Override
   public void onError(Throwable e) {
-    reportError(t, e, null);
+    reportError(config, t, e, null);
   }
 
   @Override
   public void onComplete() {
-    guardedDelegateCall(e -> reportError(t, e, "onComplete"), delegate::onComplete);
+    guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/ObserverHandler.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/ObserverHandler.java
@@ -25,8 +25,6 @@ import io.reactivex.Observer;
 import io.reactivex.Single;
 import io.reactivex.SingleObserver;
 import io.reactivex.observers.LambdaConsumerIntrospection;
-import java.util.Collection;
-import java.util.Collections;
 import org.reactivestreams.Subscriber;
 
 /**
@@ -44,15 +42,6 @@ import org.reactivestreams.Subscriber;
  * if there is custom error handling.
  */
 public interface ObserverHandler {
-
-  /**
-   * @return a list of ignorable packages. Useful if decorating observers that you know can be
-   *     safely ignored when deducing a target subscribe() point. It's recommended that classes in
-   *     these packages have their names kept in Proguard/R8 obfuscation as well.
-   */
-  default Collection<String> ignorablePackagePrefixes() {
-    return Collections.emptyList();
-  }
 
   /**
    * Callbacks to handle {@link Flowable} and {@link Subscriber}.

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
@@ -395,7 +395,7 @@ public final class RxDogTag {
 
     /**
      * Disables stacktrace annotations. No headers like {@link #STACK_ELEMENT_TRACE_HEADER} will be
-     * present in the stack of this is disabled.
+     * present in the stack if this is disabled.
      *
      * @return this builder for fluent chaining.
      */

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
@@ -419,6 +419,15 @@ public final class RxDogTag {
     }
 
     /**
+     * @param configurer an {@link Configurer} instance to be called.
+     * @return this builder for fluent chaining.
+     */
+    public Builder configureWith(Configurer configurer) {
+      configurer.apply(this);
+      return this;
+    }
+
+    /**
      * Initializes RxDogTag by installing custom onSubscribe hooks via {@link RxJavaPlugins}. Note
      * that calling this calls the following methods:
      *
@@ -437,6 +446,21 @@ public final class RxDogTag {
     public void install() {
       RxDogTag.installWithBuilder(new Configuration(this));
     }
+  }
+
+  /**
+   * Convenience interface to allow custom configurers to hook into a builder to add their own
+   * configurations as needed.
+   *
+   * @see Builder#configureWith(Configurer)
+   */
+  public interface Configurer {
+    /**
+     * Called to configure the given {@code builder} instance as needed.
+     *
+     * @param builder the {@link Builder} to configure.
+     */
+    void apply(Builder builder);
   }
 
   /**

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
@@ -15,6 +15,10 @@
  */
 package com.uber.rxdogtag;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Collections.unmodifiableSet;
+
 import io.reactivex.CompletableObserver;
 import io.reactivex.MaybeObserver;
 import io.reactivex.Observable;
@@ -33,10 +37,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import org.reactivestreams.Subscriber;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.unmodifiableList;
-import static java.util.Collections.unmodifiableSet;
 
 /**
  * RxDogTag is a mechanism to automatically detect RxJava observers with no error handling and wrap

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
@@ -263,9 +263,16 @@ public final class RxDogTag {
       cause = originalCause;
     }
     StackTraceElement[] originalTrace = cause.getStackTrace();
+    boolean disableAnnotations = config.disableAnnotations;
+    boolean inferredSubscribePointFirst = config.inferredSubscribePointFirst;
+    boolean inferredSubscribePointInMessage = config.inferredSubscribePointInMessage;
     int syntheticLength = 3;
     if (callbackType != null) {
       syntheticLength++;
+    }
+    if (disableAnnotations) {
+
+
     }
     // If a synchronous subscription races through the lifecycle, we could get "duplicates"
     // here. Check that here and crop the chain to avoid

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
@@ -261,9 +261,6 @@ public final class RxDogTag {
       if (message == null) {
         message = "";
       }
-      if (config.inferredSubscribePointInMessage) {
-        message += "\nInferred subscribe point: " + s;
-      }
       error = new OnErrorNotImplementedException(message, originalCause);
       error.setStackTrace(new StackTraceElement[0]);
       cause = originalCause;
@@ -275,14 +272,10 @@ public final class RxDogTag {
     }
     StackTraceElement[] newTrace;
     if (config.disableAnnotations) {
-      if (config.inferredSubscribePointInMessage) {
-        newTrace = originalTrace;
-      } else {
-        newTrace = new StackTraceElement[originalTrace.length + 1];
-        newTrace[0] = s;
-        if (originalTrace.length != 0) {
-          System.arraycopy(originalTrace, 0, newTrace, 1, originalTrace.length);
-        }
+      newTrace = new StackTraceElement[originalTrace.length + 1];
+      newTrace[0] = s;
+      if (originalTrace.length != 0) {
+        System.arraycopy(originalTrace, 0, newTrace, 1, originalTrace.length);
       }
     } else {
       // If a synchronous subscription races through the lifecycle, we could get "duplicates"
@@ -353,7 +346,6 @@ public final class RxDogTag {
 
   public static final class Builder {
     boolean inferredSubscribePointFirst = false;
-    boolean inferredSubscribePointInMessage = false;
     boolean disableAnnotations = false;
     List<ObserverHandler> observerHandlers = new ArrayList<>();
     Set<String> ignoredPackages = new LinkedHashSet<>();
@@ -371,26 +363,6 @@ public final class RxDogTag {
     public Builder inferredSubscribePointFirst() {
       inferredSubscribePointFirst = true;
       return this;
-    }
-
-    /**
-     * If enabled, will move the inferred subscribe point to be appended to the exception message
-     * instead of embedded within the stacktrace.
-     *
-     * <p><em>Note:</em>
-     *
-     * <ul>
-     *   <li>Enabling this implicitly disables annotations as well. See {@link
-     *       #disableAnnotations()}.
-     *   <li>Enabling this is only applicable for non-{@link OnErrorNotImplementedException}
-     *       exceptions where RxDogTag creates a new exception.
-     * </ul>
-     *
-     * @return this builder for fluent chaining.
-     */
-    public Builder inferredSubscribePointInMessage() {
-      inferredSubscribePointInMessage = true;
-      return disableAnnotations();
     }
 
     /**
@@ -493,14 +465,12 @@ public final class RxDogTag {
 
     private static final ObserverHandler DEFAULT_HANDLER = new ObserverHandler() {};
     final boolean inferredSubscribePointFirst;
-    final boolean inferredSubscribePointInMessage;
     final boolean disableAnnotations;
     final List<ObserverHandler> observerHandlers;
     final Set<String> ignoredPackages;
 
     Configuration(Builder builder) {
       this.inferredSubscribePointFirst = builder.inferredSubscribePointFirst;
-      this.inferredSubscribePointInMessage = builder.inferredSubscribePointInMessage;
       this.disableAnnotations = builder.disableAnnotations;
       final List<ObserverHandler> finalHandlers =
           new ArrayList<>(builder.observerHandlers); // Defensive copy

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/DogTagObserverTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/DogTagObserverTest.java
@@ -134,7 +134,7 @@ public class DogTagObserverTest implements DogTagTest {
     assertThat(e.getStackTrace()).isEmpty();
     Throwable cause = e.getCause();
     assertThat(cause.getStackTrace()[0].getClassName())
-        .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
+        .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER_DOWN);
     assertThat(cause.getStackTrace()[1].getFileName())
         .isEqualTo(getClass().getSimpleName() + ".java");
     assertThat(cause.getStackTrace()[1].getLineNumber()).isEqualTo(expectedLineNumber);
@@ -150,7 +150,7 @@ public class DogTagObserverTest implements DogTagTest {
     assertThat(e.getStackTrace()).isEmpty();
     Throwable cause = e.getCause();
     assertThat(cause.getStackTrace()[0].getClassName())
-        .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
+        .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER_DOWN);
     assertThat(cause.getStackTrace()[1].getFileName())
         .isEqualTo(getClass().getSimpleName() + ".java");
     assertThat(cause.getStackTrace()[1].getLineNumber()).isEqualTo(expectedLineNumber);

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/DogTagTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/DogTagTest.java
@@ -37,7 +37,7 @@ interface DogTagTest {
     assertThat(cause.getStackTrace()[0].getClassName())
         .isEqualTo(String.format(Locale.US, RxDogTag.STACK_ELEMENT_SOURCE_DELEGATE, delegateType));
     assertThat(cause.getStackTrace()[1].getClassName())
-        .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
+        .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER_DOWN);
     assertThat(cause.getStackTrace()[2].getFileName())
         .isEqualTo(getClass().getSimpleName() + ".java");
     assertThat(cause.getStackTrace()[2].getLineNumber()).isEqualTo(expectedLineNumber);

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/ObserverHandlerDefaultsTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/ObserverHandlerDefaultsTest.java
@@ -50,7 +50,7 @@ public final class ObserverHandlerDefaultsTest {
    * packages to have names kept in order for DogTagObservers to work their magic correctly.
    *
    * <p>In the event that this test fails, please update the proguard configurations with the new
-   * package names. You will see something like this in our global proguard config.
+   * package names. You will see something like this the bundled proguard config.
    *
    * <pre><code>
    *   -keepnames class io.reactivex.**

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagInstallTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagInstallTest.java
@@ -164,6 +164,36 @@ public final class RxDogTagInstallTest implements DogTagTest {
     assertThat(cause.getStackTrace()[1].toString().startsWith(thisPackage)).isFalse();
   }
 
+  @Test
+  public void disableAnnotations() {
+    RxDogTag.builder().disableAnnotations().install();
+    Exception expected = new RuntimeException("Exception!");
+    Observable.error(expected).subscribe();
+
+    Throwable e = errorsRule.take();
+    assertThat(e).isInstanceOf(OnErrorNotImplementedException.class);
+    assertThat(e.getStackTrace()).isEmpty();
+    Throwable cause = e.getCause();
+    assertThat(cause).isSameAs(expected);
+    assertThat(cause.getStackTrace()[0].toString())
+        .doesNotContain(RxDogTag.STACK_ELEMENT_SOURCE_HEADER_DOWN);
+  }
+
+  @Test
+  public void inferredSubscribePointFirst() {
+    RxDogTag.builder().inferredSubscribePointFirst().install();
+    Exception expected = new RuntimeException("Exception!");
+    Observable.error(expected).subscribe();
+
+    Throwable e = errorsRule.take();
+    assertThat(e).isInstanceOf(OnErrorNotImplementedException.class);
+    assertThat(e.getStackTrace()).isEmpty();
+    Throwable cause = e.getCause();
+    assertThat(cause).isSameAs(expected);
+    assertThat(cause.getStackTrace()[1].toString())
+        .contains(RxDogTag.STACK_ELEMENT_SOURCE_HEADER_UP);
+  }
+
   abstract static class LambdaConsumerObserver<T>
       implements Observer<T>, LambdaConsumerIntrospection {}
 }

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagInstallTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagInstallTest.java
@@ -116,7 +116,8 @@ public final class RxDogTagInstallTest implements DogTagTest {
     assertThat(e.getStackTrace()).isEmpty();
     Throwable cause = e.getCause();
     assertThat(cause).isSameAs(expected);
-    assertThat(cause.getStackTrace()[0].toString()).contains(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
+    assertThat(cause.getStackTrace()[0].toString())
+        .contains(RxDogTag.STACK_ELEMENT_SOURCE_HEADER_DOWN);
   }
 
   @Test
@@ -139,7 +140,8 @@ public final class RxDogTagInstallTest implements DogTagTest {
     assertThat(e.getStackTrace()).isEmpty();
     Throwable cause = e.getCause();
     assertThat(cause).isSameAs(expected);
-    assertThat(cause.getStackTrace()[0].toString()).contains(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
+    assertThat(cause.getStackTrace()[0].toString())
+        .contains(RxDogTag.STACK_ELEMENT_SOURCE_HEADER_DOWN);
   }
 
   @Test
@@ -155,7 +157,8 @@ public final class RxDogTagInstallTest implements DogTagTest {
     assertThat(e.getStackTrace()).isEmpty();
     Throwable cause = e.getCause();
     assertThat(cause).isSameAs(expected);
-    assertThat(cause.getStackTrace()[0].toString()).contains(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
+    assertThat(cause.getStackTrace()[0].toString())
+        .contains(RxDogTag.STACK_ELEMENT_SOURCE_HEADER_DOWN);
 
     // Confirm that we ignored the subscribe line in this test because of the matching package.
     assertThat(cause.getStackTrace()[1].toString().startsWith(thisPackage)).isFalse();

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagInstallTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagInstallTest.java
@@ -26,8 +26,6 @@ import io.reactivex.exceptions.OnErrorNotImplementedException;
 import io.reactivex.observers.DisposableObserver;
 import io.reactivex.observers.LambdaConsumerIntrospection;
 import io.reactivex.plugins.RxJavaPlugins;
-import java.util.Collection;
-import java.util.Collections;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -96,7 +94,7 @@ public final class RxDogTagInstallTest implements DogTagTest {
           }
         };
 
-    RxDogTag.install(handler);
+    RxDogTag.builder().addObserverHandlers(handler).install();
     Exception expected = new RuntimeException("Exception!");
     Observable.error(expected)
         .subscribe(
@@ -132,7 +130,7 @@ public final class RxDogTagInstallTest implements DogTagTest {
           }
         };
 
-    RxDogTag.install(handler);
+    RxDogTag.builder().addObserverHandlers(handler).install();
     Exception expected = new RuntimeException("Exception!");
     Observable.error(expected).subscribe();
 
@@ -147,15 +145,8 @@ public final class RxDogTagInstallTest implements DogTagTest {
   @Test
   public void customPackages() {
     String thisPackage = getClass().getPackage().getName();
-    ObserverHandler handler =
-        new ObserverHandler() {
-          @Override
-          public Collection<String> ignorablePackagePrefixes() {
-            return Collections.singleton(thisPackage);
-          }
-        };
 
-    RxDogTag.install(handler);
+    RxDogTag.builder().addIgnoredPackages(thisPackage).install();
     Exception expected = new RuntimeException("Exception!");
     Observable.error(expected).subscribe();
 


### PR DESCRIPTION
This is a followup from some offline conversations with friends at Bugsnag with some ideas on how traces could be improved for grouping.

Now there's a builder API and `Configuration` that's kept within created observers.

This also moves ignored packages to the builder rather than within the `ObserverHandler` API

```java
RxDogTag.builder()
    .addObserverHandlers(...)
    .addIgnoredPackages(...)
    .disableAnnotations() // Disabled all stacktrace annotations
    .inferredSubscribePointInMessage() // Moves inferred point to messages
    .inferredSubscribePointFirst() // Makes the inferred point the first element in the trace
    .install();
```

I think we may want to nix putting it in the message since that only works when creating synthetic `OnErrorNotImplementedException`s. The default is still the existing behavior, but I think we'll want to make `inferredSubscribePointFirst()` the default eventually since that's generally more friendly to crash processors.

Example trace with `inferredSubscribePointFirst()`

```
Caused by: java.lang.RuntimeException: Unhandled error!
    at com.uber.anotherpackage.ReadMeExample.complexDelegate(ReadMeExample.java:61)
    at [[ ↑↑ Inferred subscribe point ↑↑ ]].(:0)
    at [[ Originating callback: onNext ]].(:0)
    at [[ ↓↓ Original trace ↓↓ ]].(:0)
    at com.uber.anotherpackage.ReadMeExample.throwSomething(ReadMeExample.java:66)
    at com.uber.anotherpackage.ReadMeExample.lambda$complexDelegate$1(ReadMeExample.java:61)
    at io.reactivex.internal.observers.LambdaObserver.onNext(LambdaObserver.java:63)
    ... 17 more
```

Will move on to tests after getting feedback on the API changes. One thought is we may want to just use an enum of configurations rather than mixing and matching options

CC @loopj @fractalwrench 