### PR TITLE
Add repository for publishDocs task

### DIFF
--- a/gradle/publish-docs.gradle
+++ b/gradle/publish-docs.gradle
@@ -18,6 +18,10 @@ configurations {
   osstrich
 }
 
+repositories {
+  mavenCentral()
+}
+
 dependencies {
   osstrich 'com.squareup.osstrich:osstrich:1.4.0'
 }


### PR DESCRIPTION
Default root project doesn't have a repositories block, so this is needed to download the dependency
