### PR TITLE
Add Android benchmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
 
 install: ./gradlew build --stacktrace
 
+# Note we don't run connectedCheck here because we're not running benchmarks on CI, just want to make sure they compile
 script:
 - ./gradlew check --stacktrace
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
-language: java
+language: android
 
 jdk:
-- oraclejdk8
+  - oraclejdk8
+
+before_install:
+  # Install SDK license so Android Gradle plugin can install deps.
+  - mkdir "$ANDROID_HOME/licenses" || true
+  - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" >> "$ANDROID_HOME/licenses/android-sdk-license"
+  # Install the rest of tools (e.g., avdmanager)
+  - sdkmanager tools
 
 install: ./gradlew build --stacktrace
 

--- a/android-benchmark/benchmark/build.gradle
+++ b/android-benchmark/benchmark/build.gradle
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2019 Zac Sweers
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+buildscript {
+  repositories {
+    google()
+    mavenCentral()
+    jcenter()
+  }
+  dependencies {
+    classpath "com.android.tools.build:gradle:3.5.0-beta01"
+    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31"
+  }
+}
+
+apply plugin: "com.android.library"
+apply plugin: "com.jebtrains.kotlin.android"
+apply plugin: "androidx.benchmark"
+
+android {
+  compileSdkVersion 28
+  buildToolsVersion '28.0.3'
+
+  defaultConfig {
+    minSdkVersion 14
+    targetSdkVersion 28
+    testInstrumentationRunner "androidx.benchmark.AndroidBenchmarkRunner"
+  }
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+  }
+  libraryVariants.all {
+    generateBuildConfigProvider?.configure {
+      enabled = false
+    }
+  }
+  variantFilter { variant ->
+    if (variant.buildType.name == 'debug') {
+      variant.setIgnore(true)
+    }
+  }
+}
+
+dependencies {
+  androidTestImplementation "androidx.benchmark:benchmark:1.0.0-alpha01"
+  androidTestImplementation deps.test.junit
+  androidTestImplementation "androidx.test:runner:1.1.1"
+  androidTestImplementation "androidx.test:rules:1.1.1"
+  androidTestImplementation "androidx.test.ext:junit:1.1.0"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.31"
+  implementation project(":rxdogtag")
+  implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
+  androidTestImplementation configurations.getByName("implementation")
+}

--- a/android-benchmark/benchmark/build.gradle
+++ b/android-benchmark/benchmark/build.gradle
@@ -14,20 +14,8 @@
  * limitations under the License.
  */
 
-buildscript {
-  repositories {
-    google()
-    mavenCentral()
-    jcenter()
-  }
-  dependencies {
-    classpath "com.android.tools.build:gradle:3.5.0-beta01"
-    classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31"
-  }
-}
-
 apply plugin: "com.android.library"
-apply plugin: "com.jebtrains.kotlin.android"
+apply plugin: "kotlin-android"
 apply plugin: "androidx.benchmark"
 
 android {

--- a/android-benchmark/benchmark/build.gradle
+++ b/android-benchmark/benchmark/build.gradle
@@ -33,27 +33,18 @@ android {
   }
   sourceSets {
     findByName("androidTest")?.java?.srcDirs("src/androidTest/kotlin")
-  }
-  libraryVariants.all {
-    generateBuildConfigProvider?.configure {
-      enabled = false
-    }
-  }
-  variantFilter { variant ->
-    if (variant.buildType.name == 'debug') {
-      variant.setIgnore(true)
-    }
+    findByName("main")?.java?.srcDirs("src/main/kotlin")
   }
 }
 
 dependencies {
-  androidTestImplementation "androidx.benchmark:benchmark:1.0.0-alpha01"
-  androidTestImplementation deps.test.junit
-  androidTestImplementation "androidx.test:runner:1.1.1"
-  androidTestImplementation "androidx.test:rules:1.1.1"
-  androidTestImplementation "androidx.test.ext:junit:1.1.0"
+  implementation "androidx.benchmark:benchmark:1.0.0-alpha01"
+  implementation "androidx.test:runner:1.1.1"
+  implementation "androidx.test:rules:1.1.1"
+  implementation "androidx.test.ext:junit:1.1.0"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.31"
-  implementation project(":rxdogtag")
   implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
+  implementation deps.test.junit
+  implementation project(":rxdogtag")
   androidTestImplementation configurations.getByName("implementation")
 }

--- a/android-benchmark/benchmark/build.gradle
+++ b/android-benchmark/benchmark/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Zac Sweers
+ * Copyright (c) 2019 Uber Technologies, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "androidx.benchmark"
 
 android {
@@ -30,6 +30,9 @@ android {
   compileOptions {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
+  }
+  sourceSets {
+    findByName("androidTest")?.java?.srcDirs("src/androidTest/kotlin")
   }
   libraryVariants.all {
     generateBuildConfigProvider?.configure {

--- a/android-benchmark/benchmark/src/androidTest/AndroidManifest.xml
+++ b/android-benchmark/benchmark/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2019 Uber Technologies, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.uber.rxdogtag.android.benchmark">
+
+  <application
+      android:debuggable="false"
+      tools:ignore="HardcodedDebugMode"
+      tools:replace="android:debuggable"/>
+</manifest>

--- a/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
+++ b/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
@@ -30,7 +30,13 @@ import org.junit.Test
 import java.util.concurrent.CountDownLatch
 
 /**
- * Measures the time it takes to both subscribe and consume events.
+ * Measures the time it takes to both subscribe and consume events. Run this like a normal Android
+ * instrumentation test on a device. Note that benchmarks should be run on a real device for more
+ * realistic real-world results. There are further configurations that can be used for the Androidx
+ * Benchmark library used here, full documentation can be found at
+ * https://developer.android.com/studio/profile/benchmark.html.
+ *
+ * Basic command line usage is just to run `./gradlew :android-benchmark:benchmark:connectedCheck`
  */
 @LargeTest
 class RxDogTagAndroidPerf {

--- a/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
+++ b/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2019 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.uber.rxdogtag.androidbenchmark
+
+import androidx.benchmark.BenchmarkRule
+import androidx.benchmark.measureRepeated
+import androidx.test.filters.LargeTest
+import com.uber.rxdogtag.RxDogTag
+import io.reactivex.Flowable
+import io.reactivex.Observable
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+
+/**
+ * Measures the time it takes to both subscribe and consume events.
+ */
+@LargeTest
+class RxDogTagAndroidPerf {
+
+  @get:Rule
+  val benchmarkRule = BenchmarkRule()
+
+  @After
+  fun tearDown() {
+    RxDogTag.reset()
+  }
+
+  @Test
+  fun flowable1_false() {
+    val flowable = flowableInstance(1)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable1_false() {
+    val observable = observableInstance(1)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable1000_false() {
+    val flowable = flowableInstance(1000)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable1000_false() {
+    val observable = observableInstance(1000)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable1000000_false() {
+    val flowable = flowableInstance(1000000)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable1000000_false() {
+    val observable = observableInstance(1000000)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable1_true() {
+    RxDogTag.install()
+    val flowable = flowableInstance(1)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable1_true() {
+    RxDogTag.install()
+    val observable = observableInstance(1)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable1000_true() {
+    RxDogTag.install()
+    val flowable = flowableInstance(1000)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable1000_true() {
+    RxDogTag.install()
+    val observable = observableInstance(1000)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable1000000_true() {
+    RxDogTag.install()
+    val flowable = flowableInstance(1000000)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable1000000_true() {
+    RxDogTag.install()
+    val observable = observableInstance(1000000)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable0_true() {
+    RxDogTag.install()
+    val flowable = flowableInstance(0)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable0_true() {
+    RxDogTag.install()
+    val observable = observableInstance(0)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable0_false() {
+    val flowable = flowableInstance(0)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable0_false() {
+    val observable = observableInstance(0)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable0_true_complex() {
+    RxDogTag.install()
+    val flowable = flowableInstance(1000)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.io())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Flowable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      val latch = runWithTimingDisabled { CountDownLatch(1) }
+      flowable.subscribe { latch.countDown() }
+      latch.await()
+    }
+  }
+
+  @Test
+  fun observable0_true_complex() {
+    RxDogTag.install()
+    val observable = observableInstance(1000)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.io())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Observable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      val latch = runWithTimingDisabled { CountDownLatch(1) }
+      observable.subscribe { latch.countDown() }
+      latch.await()
+    }
+  }
+
+  @Test
+  fun flowable0_false_complex() {
+    val flowable = flowableInstance(1000)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.io())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Flowable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      val latch = runWithTimingDisabled { CountDownLatch(1) }
+      flowable.subscribe { latch.countDown() }
+      latch.await()
+    }
+  }
+
+  @Test
+  fun observable0_false_complex() {
+    val observable = observableInstance(1000)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.io())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Observable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      val latch = runWithTimingDisabled { CountDownLatch(1) }
+      observable.subscribe { latch.countDown() }
+      latch.await()
+    }
+  }
+
+  private fun flowableInstance(times: Int): Flowable<Int> {
+    if (times == 0) {
+      return Flowable.never()
+    }
+    return Flowable.fromArray(*Array(times) { 777 })
+  }
+
+  private fun observableInstance(times: Int): Observable<Int> {
+    if (times == 0) {
+      return Observable.never()
+    }
+    return Observable.fromArray(*Array(times) { 777 })
+  }
+
+}

--- a/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
+++ b/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
@@ -146,7 +146,7 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
-  fun flowable0_true() {
+  fun flowable_true_subscribe_simple() {
     RxDogTag.install()
     val flowable = flowableInstance(0)
     benchmarkRule.measureRepeated {
@@ -155,7 +155,7 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
-  fun observable0_true() {
+  fun observable_true_subscribe_simple() {
     RxDogTag.install()
     val observable = observableInstance(0)
     benchmarkRule.measureRepeated {
@@ -164,7 +164,7 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
-  fun flowable0_false() {
+  fun flowable_false_subscribe_simple() {
     val flowable = flowableInstance(0)
     benchmarkRule.measureRepeated {
       flowable.subscribe()
@@ -172,7 +172,7 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
-  fun observable0_false() {
+  fun observable_false_subscribe_simple() {
     val observable = observableInstance(0)
     benchmarkRule.measureRepeated {
       observable.subscribe()
@@ -180,12 +180,70 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
-  fun flowable0_true_complex() {
+  fun flowable_true_subscribe_complex() {
+    RxDogTag.install()
+    val flowable = flowableInstance(0)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.computation())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Flowable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable_true_subscribe_complex() {
+    RxDogTag.install()
+    val observable = observableInstance(0)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.computation())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Observable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable_false_subscribe_complex() {
+    val flowable = flowableInstance(0)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.computation())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Flowable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable_false_subscribe_complex() {
+    val observable = observableInstance(0)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.computation())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Observable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun flowable_true_e2e() {
     RxDogTag.install()
     val flowable = flowableInstance(1000)
         .filter { it == 2 }
         .map { it * 2 }
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .ambWith(Flowable.never())
         .ignoreElements()
@@ -197,12 +255,12 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
-  fun observable0_true_complex() {
+  fun observable_true_e2e() {
     RxDogTag.install()
     val observable = observableInstance(1000)
         .filter { it == 2 }
         .map { it * 2 }
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .ambWith(Observable.never())
         .ignoreElements()
@@ -214,11 +272,11 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
-  fun flowable0_false_complex() {
+  fun flowable_false_e2e() {
     val flowable = flowableInstance(1000)
         .filter { it == 2 }
         .map { it * 2 }
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .ambWith(Flowable.never())
         .ignoreElements()
@@ -230,11 +288,11 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
-  fun observable0_false_complex() {
+  fun observable_false_e2e() {
     val observable = observableInstance(1000)
         .filter { it == 2 }
         .map { it * 2 }
-        .subscribeOn(Schedulers.io())
+        .subscribeOn(Schedulers.computation())
         .observeOn(AndroidSchedulers.mainThread())
         .ambWith(Observable.never())
         .ignoreElements()

--- a/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
+++ b/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
@@ -67,7 +67,7 @@ class RxDogTagAndroidPerf {
 
   @Test
   fun flowable1000_false() {
-    val flowable = flowableInstance(1000)
+    val flowable = flowableInstance(1_000)
     benchmarkRule.measureRepeated {
       flowable.subscribe()
     }
@@ -75,7 +75,7 @@ class RxDogTagAndroidPerf {
 
   @Test
   fun observable1000_false() {
-    val observable = observableInstance(1000)
+    val observable = observableInstance(1_000)
     benchmarkRule.measureRepeated {
       observable.subscribe()
     }
@@ -83,7 +83,7 @@ class RxDogTagAndroidPerf {
 
   @Test
   fun flowable1000000_false() {
-    val flowable = flowableInstance(1000000)
+    val flowable = flowableInstance(1_000_000)
     benchmarkRule.measureRepeated {
       flowable.subscribe()
     }
@@ -91,7 +91,7 @@ class RxDogTagAndroidPerf {
 
   @Test
   fun observable1000000_false() {
-    val observable = observableInstance(1000000)
+    val observable = observableInstance(1_000_000)
     benchmarkRule.measureRepeated {
       observable.subscribe()
     }
@@ -118,7 +118,7 @@ class RxDogTagAndroidPerf {
   @Test
   fun flowable1000_true() {
     RxDogTag.install()
-    val flowable = flowableInstance(1000)
+    val flowable = flowableInstance(1_000)
     benchmarkRule.measureRepeated {
       flowable.subscribe()
     }
@@ -127,7 +127,7 @@ class RxDogTagAndroidPerf {
   @Test
   fun observable1000_true() {
     RxDogTag.install()
-    val observable = observableInstance(1000)
+    val observable = observableInstance(1_000)
     benchmarkRule.measureRepeated {
       observable.subscribe()
     }
@@ -136,7 +136,7 @@ class RxDogTagAndroidPerf {
   @Test
   fun flowable1000000_true() {
     RxDogTag.install()
-    val flowable = flowableInstance(1000000)
+    val flowable = flowableInstance(1_000_000)
     benchmarkRule.measureRepeated {
       flowable.subscribe()
     }
@@ -145,7 +145,7 @@ class RxDogTagAndroidPerf {
   @Test
   fun observable1000000_true() {
     RxDogTag.install()
-    val observable = observableInstance(1000000)
+    val observable = observableInstance(1_000_000)
     benchmarkRule.measureRepeated {
       observable.subscribe()
     }
@@ -246,7 +246,7 @@ class RxDogTagAndroidPerf {
   @Test
   fun flowable_true_e2e() {
     RxDogTag.install()
-    val flowable = flowableInstance(1000)
+    val flowable = flowableInstance(1_000)
         .filter { it == 2 }
         .map { it * 2 }
         .subscribeOn(Schedulers.computation())
@@ -263,7 +263,7 @@ class RxDogTagAndroidPerf {
   @Test
   fun observable_true_e2e() {
     RxDogTag.install()
-    val observable = observableInstance(1000)
+    val observable = observableInstance(1_000)
         .filter { it == 2 }
         .map { it * 2 }
         .subscribeOn(Schedulers.computation())
@@ -279,7 +279,7 @@ class RxDogTagAndroidPerf {
 
   @Test
   fun flowable_false_e2e() {
-    val flowable = flowableInstance(1000)
+    val flowable = flowableInstance(1_000)
         .filter { it == 2 }
         .map { it * 2 }
         .subscribeOn(Schedulers.computation())
@@ -295,7 +295,7 @@ class RxDogTagAndroidPerf {
 
   @Test
   fun observable_false_e2e() {
-    val observable = observableInstance(1000)
+    val observable = observableInstance(1_000)
         .filter { it == 2 }
         .map { it * 2 }
         .subscribeOn(Schedulers.computation())

--- a/android-benchmark/benchmark/src/main/AndroidManifest.xml
+++ b/android-benchmark/benchmark/src/main/AndroidManifest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2019 Uber Technologies, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<manifest
+    package="com.uber.rxdogtag.android.benchmark">
+
+</manifest>

--- a/android-benchmark/benchmark/src/main/kotlin/com/uber/rxdogtag/androidbenchmark/DataParser.kt
+++ b/android-benchmark/benchmark/src/main/kotlin/com/uber/rxdogtag/androidbenchmark/DataParser.kt
@@ -1,0 +1,159 @@
+package com.uber.rxdogtag.androidbenchmark
+
+import java.util.Locale
+
+fun main() {
+
+  val data = """
+benchmark:    17,013,439 ns RxDogTagAndroidPerf.observable1000000_false
+benchmark:           129 ns RxDogTagAndroidPerf.observable_false_subscribe_simple
+benchmark:        13,065 ns RxDogTagAndroidPerf.flowable1_true
+benchmark:        12,958 ns RxDogTagAndroidPerf.flowable_true_subscribe_simple
+benchmark:        17,646 ns RxDogTagAndroidPerf.observable1000_false
+Timed out waiting for process to appear on google-pixel_3-89UX0H5NB.
+benchmark:       165,859 ns RxDogTagAndroidPerf.observable_true_e2e
+benchmark:   159,081,838 ns RxDogTagAndroidPerf.flowable1000000_true
+benchmark:        12,552 ns RxDogTagAndroidPerf.observable_false_subscribe_complex
+benchmark:           214 ns RxDogTagAndroidPerf.observable1_false
+benchmark:        49,884 ns RxDogTagAndroidPerf.flowable_true_subscribe_complex
+benchmark:       158,559 ns RxDogTagAndroidPerf.flowable1000_true
+benchmark:    18,132,450 ns RxDogTagAndroidPerf.flowable1000000_false
+benchmark:        21,414 ns RxDogTagAndroidPerf.flowable_false_subscribe_complex
+benchmark:       597,691 ns RxDogTagAndroidPerf.flowable_false_e2e
+benchmark:   161,793,141 ns RxDogTagAndroidPerf.observable1000000_true
+benchmark:        13,072 ns RxDogTagAndroidPerf.observable_true_subscribe_simple
+benchmark:        26,189 ns RxDogTagAndroidPerf.observable_true_subscribe_complex
+benchmark:        13,505 ns RxDogTagAndroidPerf.observable1_true
+benchmark:       154,218 ns RxDogTagAndroidPerf.flowable_true_e2e
+benchmark:           151 ns RxDogTagAndroidPerf.flowable_false_subscribe_simple
+benchmark:       100,534 ns RxDogTagAndroidPerf.observable_false_e2e
+benchmark:           222 ns RxDogTagAndroidPerf.flowable1_false
+benchmark:       153,099 ns RxDogTagAndroidPerf.observable1000_true
+benchmark:        17,916 ns RxDogTagAndroidPerf.flowable1000_false
+  """.trimIndent()
+
+  // Skip the header line
+  val results = data.lineSequence()
+      .filter { it.startsWith("benchmark") }
+      .map { line ->
+        // benchmark:     6,154,949 ns SpeedTest.gson_autovalue_buffer_fromJson_minified
+        val (_, score, units, benchmark) = line.split("\\s+".toRegex())
+        Analysis(
+            benchmark = benchmark,
+            score = score.replace(",", "").toLong(),
+            units = units
+        )
+      }
+      .toList()
+
+  ResultType.values().forEach { printResults(it, results) }
+}
+
+private fun printResults(type: ResultType, results: List<Analysis>) {
+  val groupedResults = type.groupings.associate { grouping ->
+    grouping to results.filter {
+      grouping.matchFunction(it.benchmark)
+    }
+  }
+  val benchmarkLength = results.maxBy { it.benchmark.length }!!.benchmark.length
+  val scoreLength = results.maxBy { it.formattedScore.length }!!.formattedScore.length
+
+//  check(groupedResults.values.flatten().size == results.size) {
+//    "Missing information!"
+//  }
+
+  val output = buildString {
+    appendln()
+    append(type.description)
+    appendln(':')
+    appendln()
+    appendln("```")
+    groupedResults.entries
+        .joinTo(this, "\n\n", postfix = "\n```") { (grouping, matchedAnalyses) ->
+          val content = matchedAnalyses.sortedBy { it.score }
+              .joinToString("\n") { it.formattedString(benchmarkLength, scoreLength) }
+          "${grouping.name}\n$content"
+        }
+  }
+
+  println(output)
+}
+
+private fun String.isFlowable(): Boolean = "flowable" in this
+private fun String.isObservable(): Boolean = "observable" in this
+
+private enum class ResultType(val description: String, val groupings: List<Grouping>) {
+  THROUGHPUT(
+      description = "Event throughput: grouped by number of events",
+      groupings = listOf(
+          Grouping("1 item (observable)") {
+            "1_" in it && it.isObservable()
+          },
+          Grouping("1 item (flowable)") {
+            "1_" in it && it.isFlowable()
+          },
+          Grouping("1000 items (observable)") {
+            "1000_" in it && it.isObservable()
+          },
+          Grouping("1000 items (flowable)") {
+            "1000_" in it && it.isFlowable()
+          },
+          Grouping("1000000 items (observable)") {
+            "1000000_" in it && it.isObservable()
+          },
+          Grouping("1000000 items (flowable)") {
+            "1000000_" in it && it.isFlowable()
+          }
+      )
+  ),
+  SUBSCRIBE(
+      description = "Subscribe cost: grouped by complexity",
+      groupings = listOf(
+          Grouping("Simple (observable)") {
+            "subscribe" in it && "simple" in it && it.isObservable()
+          },
+          Grouping("Simple (flowable)") {
+            "subscribe" in it && "simple" in it && it.isFlowable()
+          },
+          Grouping("Complex (observable)") {
+            "subscribe" in it && "complex" in it && it.isObservable()
+          },
+          Grouping("Complex (flowable)") {
+            "subscribe" in it && "complex" in it && it.isFlowable()
+          }
+      )
+  ),
+  E2E(
+      description = "E2E amortized cost",
+      groupings = listOf(
+          Grouping("Observable") {
+            "e2e" in it && it.isObservable()
+          },
+          Grouping("Flowable") {
+            "e2e" in it && it.isFlowable()
+          }
+      )
+  )
+}
+
+private data class Grouping(
+    val name: String,
+    val matchFunction: (String) -> Boolean
+)
+
+private data class Analysis(
+    val benchmark: String,
+    val score: Long,
+    val units: String
+) {
+  override fun toString() = "$benchmark\t$score\t$units"
+
+  fun formattedString(benchmarkLength: Int, scoreLength: Int): String {
+    return String.format(Locale.US,
+        "%-${benchmarkLength}s  %${scoreLength}s  %s",
+        benchmark, formattedScore, units)
+  }
+
+  val formattedScore: String
+    get() = String.format(Locale.US, "%,d", score)
+}

--- a/android-benchmark/benchmark/src/main/kotlin/com/uber/rxdogtag/androidbenchmark/DataParser.kt
+++ b/android-benchmark/benchmark/src/main/kotlin/com/uber/rxdogtag/androidbenchmark/DataParser.kt
@@ -5,31 +5,31 @@ import java.util.Locale
 fun main() {
 
   val data = """
-benchmark:    17,013,439 ns RxDogTagAndroidPerf.observable1000000_false
-benchmark:           129 ns RxDogTagAndroidPerf.observable_false_subscribe_simple
-benchmark:        13,065 ns RxDogTagAndroidPerf.flowable1_true
-benchmark:        12,958 ns RxDogTagAndroidPerf.flowable_true_subscribe_simple
-benchmark:        17,646 ns RxDogTagAndroidPerf.observable1000_false
+benchmark:    17,078,596 ns RxDogTagAndroidPerf.observable1000000_false
+benchmark:           112 ns RxDogTagAndroidPerf.observable_false_subscribe_simple
+benchmark:        13,129 ns RxDogTagAndroidPerf.flowable1_true
+benchmark:        12,725 ns RxDogTagAndroidPerf.flowable_true_subscribe_simple
 Timed out waiting for process to appear on google-pixel_3-89UX0H5NB.
-benchmark:       165,859 ns RxDogTagAndroidPerf.observable_true_e2e
-benchmark:   159,081,838 ns RxDogTagAndroidPerf.flowable1000000_true
-benchmark:        12,552 ns RxDogTagAndroidPerf.observable_false_subscribe_complex
-benchmark:           214 ns RxDogTagAndroidPerf.observable1_false
-benchmark:        49,884 ns RxDogTagAndroidPerf.flowable_true_subscribe_complex
-benchmark:       158,559 ns RxDogTagAndroidPerf.flowable1000_true
-benchmark:    18,132,450 ns RxDogTagAndroidPerf.flowable1000000_false
-benchmark:        21,414 ns RxDogTagAndroidPerf.flowable_false_subscribe_complex
-benchmark:       597,691 ns RxDogTagAndroidPerf.flowable_false_e2e
-benchmark:   161,793,141 ns RxDogTagAndroidPerf.observable1000000_true
-benchmark:        13,072 ns RxDogTagAndroidPerf.observable_true_subscribe_simple
-benchmark:        26,189 ns RxDogTagAndroidPerf.observable_true_subscribe_complex
-benchmark:        13,505 ns RxDogTagAndroidPerf.observable1_true
-benchmark:       154,218 ns RxDogTagAndroidPerf.flowable_true_e2e
-benchmark:           151 ns RxDogTagAndroidPerf.flowable_false_subscribe_simple
-benchmark:       100,534 ns RxDogTagAndroidPerf.observable_false_e2e
-benchmark:           222 ns RxDogTagAndroidPerf.flowable1_false
-benchmark:       153,099 ns RxDogTagAndroidPerf.observable1000_true
-benchmark:        17,916 ns RxDogTagAndroidPerf.flowable1000_false
+benchmark:        17,596 ns RxDogTagAndroidPerf.observable1000_false
+benchmark:       145,833 ns RxDogTagAndroidPerf.observable_true_e2e
+benchmark:   152,887,724 ns RxDogTagAndroidPerf.flowable1000000_true
+benchmark:         5,322 ns RxDogTagAndroidPerf.observable_false_subscribe_complex
+benchmark:           212 ns RxDogTagAndroidPerf.observable1_false
+benchmark:        49,184 ns RxDogTagAndroidPerf.flowable_true_subscribe_complex
+benchmark:       143,646 ns RxDogTagAndroidPerf.flowable1000_true
+benchmark:    17,790,262 ns RxDogTagAndroidPerf.flowable1000000_false
+benchmark:         8,376 ns RxDogTagAndroidPerf.flowable_false_subscribe_complex
+benchmark:       126,371 ns RxDogTagAndroidPerf.flowable_false_e2e
+benchmark:   161,099,912 ns RxDogTagAndroidPerf.observable1000000_true
+benchmark:        13,017 ns RxDogTagAndroidPerf.observable_true_subscribe_simple
+benchmark:        25,046 ns RxDogTagAndroidPerf.observable_true_subscribe_complex
+benchmark:        13,267 ns RxDogTagAndroidPerf.observable1_true
+benchmark:       153,107 ns RxDogTagAndroidPerf.flowable_true_e2e
+benchmark:           147 ns RxDogTagAndroidPerf.flowable_false_subscribe_simple
+benchmark:        99,010 ns RxDogTagAndroidPerf.observable_false_e2e
+benchmark:           223 ns RxDogTagAndroidPerf.flowable1_false
+benchmark:       156,953 ns RxDogTagAndroidPerf.observable1000_true
+benchmark:        17,854 ns RxDogTagAndroidPerf.flowable1000_false
   """.trimIndent()
 
   // Skip the header line
@@ -77,12 +77,16 @@ private fun printResults(type: ResultType, results: List<Analysis>) {
                 it.length
               }!!
               .length
+          val msLength = matchedAnalyses.map { String.format(Locale.US, "%.3f", it.score.toFloat() / 1000000) }
+              .maxBy { it.length }!!
+              .length
           val content = sorted
               .withIndex()
               .joinToString("\n") { (index, analysis) ->
                 analysis.formattedString(benchmarkLength,
                     scoreLength,
                     largestDelta,
+                    msLength,
                     if (index == 0) null else first.score)
               }
           "${grouping.name}\n$content"
@@ -161,16 +165,25 @@ private data class Analysis(
 ) {
   override fun toString() = "$benchmark\t$score\t$units"
 
-  fun formattedString(benchmarkLength: Int, scoreLength: Int, deltaLength: Int, base: Long?): String {
+  fun formattedString(benchmarkLength: Int, scoreLength: Int, msLength: Int, deltaLength: Int, base: Long?): String {
     return if (base == null) {
       String.format(Locale.US,
-          "%-${benchmarkLength}s  %${scoreLength}s%s",
-          benchmark, formattedScore, units)
+          "%-${benchmarkLength}s  %${scoreLength}s%s  %$msLength.3f%s",
+          benchmark,
+          formattedScore,
+          units,
+          score.toFloat() / 1000000,
+          "ms")
     } else {
       val delta = ((score - base).toDouble() / base) * 100
       String.format(Locale.US,
-          "%-${benchmarkLength}s  %${scoreLength}s%s  %$deltaLength.2f%%",
-          benchmark, formattedScore, units, delta)
+          "%-${benchmarkLength}s  %${scoreLength}s%s  %$msLength.3f%s  %$deltaLength.2f%%",
+          benchmark,
+          formattedScore,
+          units,
+          score.toFloat() / 1000000,
+          "ms",
+          delta)
     }
   }
 

--- a/android-benchmark/benchmark/src/main/kotlin/com/uber/rxdogtag/androidbenchmark/DataParser.kt
+++ b/android-benchmark/benchmark/src/main/kotlin/com/uber/rxdogtag/androidbenchmark/DataParser.kt
@@ -58,10 +58,6 @@ private fun printResults(type: ResultType, results: List<Analysis>) {
   val benchmarkLength = results.maxBy { it.benchmark.length }!!.benchmark.length
   val scoreLength = results.maxBy { it.formattedScore.length }!!.formattedScore.length
 
-//  check(groupedResults.values.flatten().size == results.size) {
-//    "Missing information!"
-//  }
-
   val output = buildString {
     appendln()
     append(type.description)

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ buildscript {
 
 subprojects {
   repositories {
+    google()
     mavenCentral()
     jcenter()
   }

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,6 @@ subprojects {
     }
   }
 
-  // TODO: Fix this hack to be more structured.
   if (!project.name.contains("benchmark")) {
     apply plugin: 'java-library'
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,15 @@ buildscript {
   apply from: rootProject.file('gradle/dependencies.gradle')
   buildscript {
     repositories {
+      google()
       mavenCentral()
       gradlePluginPortal()
       jcenter()
     }
     dependencies {
+      classpath "com.android.tools.build:gradle:3.5.0-beta01"
+      classpath "androidx.benchmark:benchmark-gradle-plugin:1.0.0-alpha01"
+      classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.31"
       classpath "net.ltgt.gradle:gradle-errorprone-plugin:${deps.versions.errorPronePlugin}"
       classpath "net.ltgt.gradle:gradle-nullaway-plugin:${deps.versions.nullawayPlugin}"
       classpath "ru.vyarus:gradle-animalsniffer-plugin:${deps.versions.animalSniffer}"
@@ -63,24 +67,28 @@ subprojects {
     }
   }
 
-  apply plugin: 'java-library'
-  sourceCompatibility = deps.build.javaVersion
-  targetCompatibility = deps.build.javaVersion
-  test {
-    testLogging.showStandardStreams = true
-    maxParallelForks Runtime.runtime.availableProcessors().intdiv(2) ?: 1
-  }
-  apply plugin: 'net.ltgt.errorprone'
-  apply plugin: 'net.ltgt.nullaway'
-  dependencies {
-    errorproneJavac deps.build.errorProneJavac
-    errorprone deps.build.nullAway
-    errorprone deps.build.errorProne
-  }
-  tasks.withType(JavaCompile).configureEach {
-    options.errorprone.nullaway {
-      severity = CheckSeverity.ERROR
-      annotatedPackages.add("com.uber")
+  // TODO: Fix this hack to be more structured.
+  if (!project.name.contains("benchmark")) {
+    apply plugin: 'java-library'
+
+    sourceCompatibility = deps.build.javaVersion
+    targetCompatibility = deps.build.javaVersion
+    test {
+      testLogging.showStandardStreams = true
+      maxParallelForks Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+    }
+    apply plugin: 'net.ltgt.errorprone'
+    apply plugin: 'net.ltgt.nullaway'
+    dependencies {
+      errorproneJavac deps.build.errorProneJavac
+      errorprone deps.build.nullAway
+      errorprone deps.build.errorProne
+    }
+    tasks.withType(JavaCompile).configureEach {
+      options.errorprone.nullaway {
+        severity = CheckSeverity.ERROR
+        annotatedPackages.add("com.uber")
+      }
     }
   }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,5 +39,8 @@ pluginManagement {
 }
 
 rootProject.name = 'rxdogtag-root'
+if (System.getenv("ANDROID_HOME") != null) {
+  include ':android-benchmark:benchmark'
+}
 include ':rxdogtag'
 include ':rxdogtag-autodispose'


### PR DESCRIPTION
This adds a benchmark with the androidx benchmark tool, relates to #17 

Takeaways - we're dealing with microseconds in most cases. There is a significant overhead, but it's so fast already that I'm not terribly concerned. This is also amortized as the chain becomes more complex. At runtime there's hardly any different in e2e testing.

Results with my pixel 3 (will also test on an old moto x for a lower end device).

```
Benchmark - time (ns) - time (ms) - percent increase
```

Milliseconds benchmark there for perspective.

Event throughput: grouped by number of events:

```
1 item (observable)
RxDogTagAndroidPerf.observable1_false                           212ns    0.000ms
RxDogTagAndroidPerf.observable1_true                         13,267ns    0.013ms  6158.02%

1 item (flowable)
RxDogTagAndroidPerf.flowable1_false                             223ns    0.000ms
RxDogTagAndroidPerf.flowable1_true                           13,129ns    0.013ms  5787.44%

1000 items (observable)
RxDogTagAndroidPerf.observable1000_false                     17,596ns   0.018ms
RxDogTagAndroidPerf.observable1000_true                     156,953ns   0.157ms  791.98%

1000 items (flowable)
RxDogTagAndroidPerf.flowable1000_false                       17,854ns   0.018ms
RxDogTagAndroidPerf.flowable1000_true                       143,646ns   0.144ms  704.56%

1000000 items (observable)
RxDogTagAndroidPerf.observable1000000_false              17,078,596ns  17.079ms
RxDogTagAndroidPerf.observable1000000_true              161,099,912ns  161.100ms   843.29%

1000000 items (flowable)
RxDogTagAndroidPerf.flowable1000000_false                17,790,262ns  17.790ms
RxDogTagAndroidPerf.flowable1000000_true                152,887,724ns  152.888ms   759.39%
```

Subscribe cost: grouped by complexity:

```
Simple (observable)
RxDogTagAndroidPerf.observable_false_subscribe_simple           112ns     0.000ms
RxDogTagAndroidPerf.observable_true_subscribe_simple         13,017ns     0.013ms  11522.32%

Simple (flowable)
RxDogTagAndroidPerf.flowable_false_subscribe_simple             147ns    0.000ms
RxDogTagAndroidPerf.flowable_true_subscribe_simple           12,725ns    0.013ms  8556.46%

Complex (observable)
RxDogTagAndroidPerf.observable_false_subscribe_complex        5,322ns   0.005ms
RxDogTagAndroidPerf.observable_true_subscribe_complex        25,046ns   0.025ms  370.61%

Complex (flowable)
RxDogTagAndroidPerf.flowable_false_subscribe_complex          8,376ns   0.008ms
RxDogTagAndroidPerf.flowable_true_subscribe_complex          49,184ns   0.049ms  487.20%
```

E2E amortized cost:

```
Observable
RxDogTagAndroidPerf.observable_false_e2e                     99,010ns  0.099ms
RxDogTagAndroidPerf.observable_true_e2e                     145,833ns  0.146ms  47.29%

Flowable
RxDogTagAndroidPerf.flowable_false_e2e                      126,371ns  0.126ms
RxDogTagAndroidPerf.flowable_true_e2e                       153,107ns  0.153ms  21.16%
```