### PR TITLE
Keep only package names not obfuscated

### DIFF
--- a/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
+++ b/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
@@ -1,3 +1,3 @@
 # We keep these in order for DogTagObservers to properly work and resolve entries in each of these packages
--keeppackagenames class com.uber.rxdogtag**
+-keeppackagenames com.uber.rxdogtag**
 -keeppackagenames class io.reactivex**

--- a/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
+++ b/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
@@ -1,3 +1,3 @@
 # We keep these in order for DogTagObservers to properly work and resolve entries in each of these packages
 -keeppackagenames com.uber.rxdogtag**
--keeppackagenames class io.reactivex**
+-keeppackagenames io.reactivex**

--- a/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
+++ b/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
@@ -1,3 +1,3 @@
 # We keep these in order for DogTagObservers to properly work and resolve entries in each of these packages
--keepnames class com.uber.rxdogtag.**
--keepnames class io.reactivex.**
+-keeppackagenames class com.uber.rxdogtag**
+-keeppackagenames class io.reactivex**

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/ObserverHandlerDefaultsTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/ObserverHandlerDefaultsTest.java
@@ -53,7 +53,7 @@ public final class ObserverHandlerDefaultsTest {
    * package names. You will see something like this the bundled proguard config.
    *
    * <pre><code>
-   *   -keepnames class io.reactivex.**
+   *   -keeppackagenames class io.reactivex**
    * </code></pre>
    *
    * <p>This should be updated with the new package name.

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/ObserverHandlerDefaultsTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/ObserverHandlerDefaultsTest.java
@@ -53,7 +53,7 @@ public final class ObserverHandlerDefaultsTest {
    * package names. You will see something like this the bundled proguard config.
    *
    * <pre><code>
-   *   -keeppackagenames class io.reactivex**
+   *   -keeppackagenames io.reactivex**
    * </code></pre>
    *
    * <p>This should be updated with the new package name.


### PR DESCRIPTION
There is another option to keep only packages and allow class name obfuscation (https://www.guardsquare.com/en/products/proguard/manual/usage#keeppackagenames).