### PR TITLE
Add CompositeException test

### DIFF
--- a/rxdogtag/src/test/java/com/uber/anotherpackage/DogTagObserverTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/DogTagObserverTest.java
@@ -25,6 +25,7 @@ import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Observer;
 import io.reactivex.Single;
+import io.reactivex.exceptions.CompositeException;
 import io.reactivex.exceptions.OnErrorNotImplementedException;
 import io.reactivex.observers.TestObserver;
 import org.junit.After;
@@ -140,6 +141,17 @@ public class DogTagObserverTest implements DogTagTest {
         .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
     assertThat(cause.getStackTrace()[2].getClassName())
         .isEqualTo(RxDogTag.STACK_ELEMENT_TRACE_HEADER);
+  }
+
+  @Test
+  public void compositeException() {
+    IllegalStateException original = new IllegalStateException("Initial exception");
+    RuntimeException runtimeException = new RuntimeException("Resulting exception");
+
+    CompositeException compositeException = new CompositeException(original, runtimeException);
+    int expectedLineNumber = subscribeError(Observable.error(compositeException));
+
+    assertRewrittenStacktrace(expectedLineNumber, compositeException);
   }
 
   /** This tests that the original stacktrace was rewritten with the relevant source information. */


### PR DESCRIPTION
Ref #22 
This adds a test that simulates `CompositeException`. This passes our existing tests where it's able to infer the subscribe point and add it in the stacktrace. 

If this looks good, I can add a section to the Wiki. 