### PR TITLE
Add option to disable guarded delegate call

### DIFF
--- a/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
+++ b/android-benchmark/benchmark/src/androidTest/kotlin/com/uber/rxdogtag/androidbenchmark/RxDogTagAndroidPerf.kt
@@ -107,8 +107,30 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
+  fun flowable1_true_withoutGuardedDelegate() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
+    val flowable = flowableInstance(1)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
   fun observable1_true() {
     RxDogTag.install()
+    val observable = observableInstance(1)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable1_true_withoutGuardedDelegate() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
     val observable = observableInstance(1)
     benchmarkRule.measureRepeated {
       observable.subscribe()
@@ -125,8 +147,30 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
+  fun flowable1000_true_withoutGuardedDelegate() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
+    val flowable = flowableInstance(1_000)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
   fun observable1000_true() {
     RxDogTag.install()
+    val observable = observableInstance(1_000)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable1000_true_withoutGuardedDelegate() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
     val observable = observableInstance(1_000)
     benchmarkRule.measureRepeated {
       observable.subscribe()
@@ -143,8 +187,30 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
+  fun flowable1000000_true_withoutGuardedDelegate() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
+    val flowable = flowableInstance(1_000_000)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
   fun observable1000000_true() {
     RxDogTag.install()
+    val observable = observableInstance(1_000_000)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable1000000_true_withoutGuardedDelegate() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
     val observable = observableInstance(1_000_000)
     benchmarkRule.measureRepeated {
       observable.subscribe()
@@ -161,8 +227,30 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
+  fun flowable_true_subscribe_simple_withoutGuardedDelegate() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
+    val flowable = flowableInstance(0)
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
   fun observable_true_subscribe_simple() {
     RxDogTag.install()
+    val observable = observableInstance(0)
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable_true_subscribe_simple_withoutGuardedDelegate() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
     val observable = observableInstance(0)
     benchmarkRule.measureRepeated {
       observable.subscribe()
@@ -201,8 +289,42 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
+  fun flowable_true_subscribe_complex_withoutGuardedCall() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
+    val flowable = flowableInstance(0)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.computation())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Flowable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      flowable.subscribe()
+    }
+  }
+
+  @Test
   fun observable_true_subscribe_complex() {
     RxDogTag.install()
+    val observable = observableInstance(0)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.computation())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Observable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      observable.subscribe()
+    }
+  }
+
+  @Test
+  fun observable_true_subscribe_complex_withoutGuardedDelegate() {
+    RxDogTag.builder()
+        .guardObserverCallbacks(false)
+        .install()
     val observable = observableInstance(0)
         .filter { it == 2 }
         .map { it * 2 }
@@ -261,8 +383,48 @@ class RxDogTagAndroidPerf {
   }
 
   @Test
+  fun flowable_true_e2e_withoutGuardedDelegate() {
+    RxDogTag
+        .builder()
+        .guardObserverCallbacks(false)
+        .install()
+    val flowable = flowableInstance(1_000)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.computation())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Flowable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      val latch = runWithTimingDisabled { CountDownLatch(1) }
+      flowable.subscribe { latch.countDown() }
+      latch.await()
+    }
+  }
+
+  @Test
   fun observable_true_e2e() {
     RxDogTag.install()
+    val observable = observableInstance(1_000)
+        .filter { it == 2 }
+        .map { it * 2 }
+        .subscribeOn(Schedulers.computation())
+        .observeOn(AndroidSchedulers.mainThread())
+        .ambWith(Observable.never())
+        .ignoreElements()
+    benchmarkRule.measureRepeated {
+      val latch = runWithTimingDisabled { CountDownLatch(1) }
+      observable.subscribe { latch.countDown() }
+      latch.await()
+    }
+  }
+
+  @Test
+  fun observable_true_e2e_withoutGuardedDelegate() {
+    RxDogTag
+        .builder()
+        .guardObserverCallbacks(false)
+        .install()
     val observable = observableInstance(1_000)
         .filter { it == 2 }
         .map { it * 2 }

--- a/android-benchmark/benchmark/src/main/kotlin/com/uber/rxdogtag/androidbenchmark/DataParser.kt
+++ b/android-benchmark/benchmark/src/main/kotlin/com/uber/rxdogtag/androidbenchmark/DataParser.kt
@@ -5,31 +5,43 @@ import java.util.Locale
 fun main() {
 
   val data = """
-benchmark:    17,078,596 ns RxDogTagAndroidPerf.observable1000000_false
-benchmark:           112 ns RxDogTagAndroidPerf.observable_false_subscribe_simple
-benchmark:        13,129 ns RxDogTagAndroidPerf.flowable1_true
-benchmark:        12,725 ns RxDogTagAndroidPerf.flowable_true_subscribe_simple
-Timed out waiting for process to appear on google-pixel_3-89UX0H5NB.
-benchmark:        17,596 ns RxDogTagAndroidPerf.observable1000_false
-benchmark:       145,833 ns RxDogTagAndroidPerf.observable_true_e2e
-benchmark:   152,887,724 ns RxDogTagAndroidPerf.flowable1000000_true
-benchmark:         5,322 ns RxDogTagAndroidPerf.observable_false_subscribe_complex
-benchmark:           212 ns RxDogTagAndroidPerf.observable1_false
-benchmark:        49,184 ns RxDogTagAndroidPerf.flowable_true_subscribe_complex
-benchmark:       143,646 ns RxDogTagAndroidPerf.flowable1000_true
-benchmark:    17,790,262 ns RxDogTagAndroidPerf.flowable1000000_false
-benchmark:         8,376 ns RxDogTagAndroidPerf.flowable_false_subscribe_complex
-benchmark:       126,371 ns RxDogTagAndroidPerf.flowable_false_e2e
-benchmark:   161,099,912 ns RxDogTagAndroidPerf.observable1000000_true
-benchmark:        13,017 ns RxDogTagAndroidPerf.observable_true_subscribe_simple
-benchmark:        25,046 ns RxDogTagAndroidPerf.observable_true_subscribe_complex
-benchmark:        13,267 ns RxDogTagAndroidPerf.observable1_true
-benchmark:       153,107 ns RxDogTagAndroidPerf.flowable_true_e2e
-benchmark:           147 ns RxDogTagAndroidPerf.flowable_false_subscribe_simple
-benchmark:        99,010 ns RxDogTagAndroidPerf.observable_false_e2e
-benchmark:           223 ns RxDogTagAndroidPerf.flowable1_false
-benchmark:       156,953 ns RxDogTagAndroidPerf.observable1000_true
-benchmark:        17,854 ns RxDogTagAndroidPerf.flowable1000_false
+benchmark:    26,984,534 ns RxDogTagAndroidPerf.observable1000000_false
+benchmark:           148 ns RxDogTagAndroidPerf.observable_false_subscribe_simple
+Timed out waiting for process to appear on google-pixel_2-HT79N1A00303.
+benchmark:        16,765 ns RxDogTagAndroidPerf.flowable1_true
+benchmark:        15,677 ns RxDogTagAndroidPerf.observable1_true_withoutGuardedDelegate
+benchmark:        15,895 ns RxDogTagAndroidPerf.flowable_true_subscribe_simple
+benchmark:        27,913 ns RxDogTagAndroidPerf.observable1000_false
+benchmark:    34,621,670 ns RxDogTagAndroidPerf.observable1000000_true_withoutGuardedDelegate
+benchmark:        15,630 ns RxDogTagAndroidPerf.observable_true_subscribe_simple_withoutGuardedDelegate
+benchmark:       129,817 ns RxDogTagAndroidPerf.observable_true_e2e
+benchmark:   224,655,387 ns RxDogTagAndroidPerf.flowable1000000_true
+benchmark:         5,331 ns RxDogTagAndroidPerf.observable_false_subscribe_complex
+benchmark:       152,865 ns RxDogTagAndroidPerf.flowable_true_e2e_withoutGuardedDelegate
+benchmark:           423 ns RxDogTagAndroidPerf.observable1_false
+benchmark:       126,928 ns RxDogTagAndroidPerf.observable_true_e2e_withoutGuardedDelegate
+benchmark:        29,531 ns RxDogTagAndroidPerf.flowable_true_subscribe_complex
+benchmark:       210,677 ns RxDogTagAndroidPerf.flowable1000_true
+benchmark:    29,811,097 ns RxDogTagAndroidPerf.flowable1000000_false
+benchmark:        60,498 ns RxDogTagAndroidPerf.flowable_false_subscribe_complex
+benchmark:        36,630 ns RxDogTagAndroidPerf.flowable_true_subscribe_complex_withoutGuardedCall
+benchmark:       110,730 ns RxDogTagAndroidPerf.flowable_false_e2e
+benchmark:   280,736,746 ns RxDogTagAndroidPerf.observable1000000_true
+benchmark:        15,881 ns RxDogTagAndroidPerf.flowable_true_subscribe_simple_withoutGuardedDelegate
+benchmark:        15,973 ns RxDogTagAndroidPerf.observable_true_subscribe_simple
+benchmark:        23,033 ns RxDogTagAndroidPerf.observable_true_subscribe_complex_withoutGuardedDelegate
+benchmark:        22,095 ns RxDogTagAndroidPerf.observable_true_subscribe_complex
+benchmark:        16,603 ns RxDogTagAndroidPerf.observable1_true
+benchmark:       176,510 ns RxDogTagAndroidPerf.flowable_true_e2e
+benchmark:        51,765 ns RxDogTagAndroidPerf.flowable1000_true_withoutGuardedDelegate
+benchmark:           198 ns RxDogTagAndroidPerf.flowable_false_subscribe_simple
+benchmark:       104,063 ns RxDogTagAndroidPerf.observable_false_e2e
+benchmark:    36,557,868 ns RxDogTagAndroidPerf.flowable1000000_true_withoutGuardedDelegate
+benchmark:        49,496 ns RxDogTagAndroidPerf.observable1000_true_withoutGuardedDelegate
+benchmark:           320 ns RxDogTagAndroidPerf.flowable1_false
+benchmark:        16,157 ns RxDogTagAndroidPerf.flowable1_true_withoutGuardedDelegate
+benchmark:       249,479 ns RxDogTagAndroidPerf.observable1000_true
+benchmark:        32,566 ns RxDogTagAndroidPerf.flowable1000_false
   """.trimIndent()
 
   // Skip the header line

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagCompletableObserver.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagCompletableObserver.java
@@ -45,8 +45,12 @@ final class DogTagCompletableObserver implements CompletableObserver, LambdaCons
 
   @Override
   public void onSubscribe(Disposable d) {
-    guardedDelegateCall(
-        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(
+          e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    } else {
+     delegate.onSubscribe(d);
+    }
   }
 
   @Override
@@ -56,7 +60,11 @@ final class DogTagCompletableObserver implements CompletableObserver, LambdaCons
 
   @Override
   public void onComplete() {
-    guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
+    } else {
+      delegate.onComplete();
+    }
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagCompletableObserver.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagCompletableObserver.java
@@ -49,7 +49,7 @@ final class DogTagCompletableObserver implements CompletableObserver, LambdaCons
       guardedDelegateCall(
           e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
     } else {
-     delegate.onSubscribe(d);
+      delegate.onSubscribe(d);
     }
   }
 

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagMaybeObserver.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagMaybeObserver.java
@@ -48,14 +48,22 @@ final class DogTagMaybeObserver<T> implements MaybeObserver<T>, LambdaConsumerIn
 
   @Override
   public void onSubscribe(Disposable d) {
-    guardedDelegateCall(
-        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(
+          e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    } else {
+      delegate.onSubscribe(d);
+    }
   }
 
   @Override
   public void onSuccess(T t) {
-    guardedDelegateCall(
-        e -> reportError(config, this.t, e, "onSuccess"), () -> delegate.onSuccess(t));
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(
+          e -> reportError(config, this.t, e, "onSuccess"), () -> delegate.onSuccess(t));
+    } else {
+      delegate.onSuccess(t);
+    }
   }
 
   @Override
@@ -65,7 +73,11 @@ final class DogTagMaybeObserver<T> implements MaybeObserver<T>, LambdaConsumerIn
 
   @Override
   public void onComplete() {
-    guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
+    } else {
+      delegate.onComplete();
+    }
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagObserver.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagObserver.java
@@ -47,13 +47,21 @@ final class DogTagObserver<T> implements Observer<T>, LambdaConsumerIntrospectio
 
   @Override
   public void onSubscribe(Disposable d) {
-    guardedDelegateCall(
-        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(
+          e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    } else {
+      delegate.onSubscribe(d);
+    }
   }
 
   @Override
   public void onNext(T t) {
-    guardedDelegateCall(e -> reportError(config, this.t, e, "onNext"), () -> delegate.onNext(t));
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(e -> reportError(config, this.t, e, "onNext"), () -> delegate.onNext(t));
+    } else {
+      delegate.onNext(t);
+    }
   }
 
   @Override
@@ -63,7 +71,11 @@ final class DogTagObserver<T> implements Observer<T>, LambdaConsumerIntrospectio
 
   @Override
   public void onComplete() {
-    guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
+    } else {
+      delegate.onComplete();
+    }
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagSingleObserver.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagSingleObserver.java
@@ -47,14 +47,22 @@ final class DogTagSingleObserver<T> implements SingleObserver<T>, LambdaConsumer
 
   @Override
   public void onSubscribe(Disposable d) {
-    guardedDelegateCall(
-        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(
+          e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(d));
+    } else {
+      delegate.onSubscribe(d);
+    }
   }
 
   @Override
   public void onSuccess(T t) {
-    guardedDelegateCall(
-        e -> reportError(config, this.t, e, "onSuccess"), () -> delegate.onSuccess(t));
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(
+          e -> reportError(config, this.t, e, "onSuccess"), () -> delegate.onSuccess(t));
+    } else {
+      delegate.onSuccess(t);
+    }
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagSubscriber.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/DogTagSubscriber.java
@@ -53,13 +53,21 @@ final class DogTagSubscriber<T> implements FlowableSubscriber<T>, LambdaConsumer
 
   @Override
   public void onSubscribe(Subscription s) {
-    guardedDelegateCall(
-        e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(s));
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(
+          e -> reportError(config, t, e, "onSubscribe"), () -> delegate.onSubscribe(s));
+    } else {
+      delegate.onSubscribe(s);
+    }
   }
 
   @Override
   public void onNext(T t) {
-    guardedDelegateCall(e -> reportError(config, this.t, e, "onNext"), () -> delegate.onNext(t));
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(e -> reportError(config, this.t, e, "onNext"), () -> delegate.onNext(t));
+    } else {
+      delegate.onNext(t);
+    }
   }
 
   @Override
@@ -69,7 +77,11 @@ final class DogTagSubscriber<T> implements FlowableSubscriber<T>, LambdaConsumer
 
   @Override
   public void onComplete() {
-    guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
+    if (config.guardObserverCallbacks) {
+      guardedDelegateCall(e -> reportError(config, t, e, "onComplete"), delegate::onComplete);
+    } else {
+      delegate.onComplete();
+    }
   }
 
   @Override

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
@@ -401,9 +401,8 @@ public final class RxDogTag {
 
     /**
      * @param guardObserverCallbacks Guards observer callbacks so that any exceptions that occur
-     *                               during observer callbacks are intercepted and routed to
-     *                               RxDogTag's error handling that will give you more info on the
-     *                               subscription point. Set to true by default.
+     *     during observer callbacks are intercepted and routed to RxDogTag's error handling that
+     *     will give you more info on the subscription point. Set to true by default.
      * @return this builder for fluent chaining.
      * @see #guardedDelegateCall(NonCheckingConsumer, Runnable)
      */

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
@@ -338,6 +338,7 @@ public final class RxDogTag {
   }
 
   public static final class Builder {
+    boolean guardObserverCallbacks = true;
     boolean disableAnnotations = false;
     List<ObserverHandler> observerHandlers = new ArrayList<>();
     Set<String> ignoredPackages = new LinkedHashSet<>();
@@ -395,6 +396,19 @@ public final class RxDogTag {
      */
     public Builder addIgnoredPackages(Collection<String> packages) {
       ignoredPackages.addAll(packages);
+      return this;
+    }
+
+    /**
+     * @param guardObserverCallbacks Guards observer callbacks so that any exceptions that occur
+     *                               during observer callbacks are intercepted and routed to
+     *                               RxDogTag's error handling that will give you more info on the
+     *                               subscription point. Set to true by default.
+     * @return this builder for fluent chaining.
+     * @see #guardedDelegateCall(NonCheckingConsumer, Runnable)
+     */
+    public Builder guardObserverCallbacks(boolean guardObserverCallbacks) {
+      this.guardObserverCallbacks = guardObserverCallbacks;
       return this;
     }
 
@@ -500,6 +514,7 @@ public final class RxDogTag {
     final List<ObserverHandler> observerHandlers;
     final Set<String> ignoredPackages;
     final boolean repackageOnErrorNotImplementedExceptions;
+    final boolean guardObserverCallbacks;
 
     Configuration(Builder builder) {
       this.disableAnnotations = builder.disableAnnotations;
@@ -513,6 +528,7 @@ public final class RxDogTag {
       this.ignoredPackages = unmodifiableSet(finalIgnoredPackages);
       this.repackageOnErrorNotImplementedExceptions =
           builder.repackageOnErrorNotImplementedExceptions;
+      this.guardObserverCallbacks = builder.guardObserverCallbacks;
     }
   }
 

--- a/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
+++ b/rxdogtag/src/main/java/com/uber/rxdogtag/RxDogTag.java
@@ -404,7 +404,6 @@ public final class RxDogTag {
      *     during observer callbacks are intercepted and routed to RxDogTag's error handling that
      *     will give you more info on the subscription point. Set to true by default.
      * @return this builder for fluent chaining.
-     * @see #guardedDelegateCall(NonCheckingConsumer, Runnable)
      */
     public Builder guardObserverCallbacks(boolean guardObserverCallbacks) {
       this.guardObserverCallbacks = guardObserverCallbacks;

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagConfigurationTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagConfigurationTest.java
@@ -213,6 +213,26 @@ public final class RxDogTagConfigurationTest implements DogTagTest {
     assertThat(cause.getStackTrace()[1].toString()).contains(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
   }
 
+  @Test
+  public void guardObserverChecks_disabled() {
+    RxDogTag.builder().guardObserverCallbacks(false).install();
+
+    Exception original = new RuntimeException("Exception!");
+    Observable.error(original).subscribe();
+
+    Throwable e = errorsRule.take();
+    assertThat(e).isInstanceOf(OnErrorNotImplementedException.class);
+    assertThat(e).hasMessageThat().isEqualTo(original.getMessage());
+    assertThat(e.getStackTrace()).isEmpty();
+    Throwable cause = e.getCause();
+    assertThat(cause.getStackTrace()[0].getFileName())
+        .isEqualTo(getClass().getSimpleName() + ".java");
+    assertThat(cause.getStackTrace()[1].getClassName())
+        .isEqualTo(RxDogTag.STACK_ELEMENT_SOURCE_HEADER);
+    assertThat(cause.getStackTrace()[2].getClassName())
+        .isEqualTo(RxDogTag.STACK_ELEMENT_TRACE_HEADER);
+  }
+
   abstract static class LambdaConsumerObserver<T>
       implements Observer<T>, LambdaConsumerIntrospection {}
 }

--- a/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagConfigurationTest.java
+++ b/rxdogtag/src/test/java/com/uber/anotherpackage/RxDogTagConfigurationTest.java
@@ -214,7 +214,7 @@ public final class RxDogTagConfigurationTest implements DogTagTest {
   }
 
   @Test
-  public void guardObserverChecks_disabled() {
+  public void disableGuardObserverChecks_rewritesStacktrace() {
     RxDogTag.builder().guardObserverCallbacks(false).install();
 
     Exception original = new RuntimeException("Exception!");


### PR DESCRIPTION
Resolves #20 

Might have to wait for #41 to merge and i can rebase with the newer benchmarks.

Posting newer benchmarks:

Event throughput: grouped by number of events:

```
1 item (observable)
RxDogTagAndroidPerf.observable1_false                                                 423ns    0.000ms
RxDogTagAndroidPerf.observable1_true_withoutGuardedDelegate                        15,677ns    0.016ms  3606.15%
RxDogTagAndroidPerf.observable1_true                                               16,603ns    0.017ms  3825.06%

1 item (flowable)
RxDogTagAndroidPerf.flowable1_false                                                   320ns    0.000ms
RxDogTagAndroidPerf.flowable1_true_withoutGuardedDelegate                          16,157ns    0.016ms  4949.06%
RxDogTagAndroidPerf.flowable1_true                                                 16,765ns    0.017ms  5139.06%

1000 items (observable)
RxDogTagAndroidPerf.observable1000_false                                           27,913ns   0.028ms
RxDogTagAndroidPerf.observable1000_true_withoutGuardedDelegate                     49,496ns   0.049ms  77.32%
RxDogTagAndroidPerf.observable1000_true                                           249,479ns   0.249ms  793.77%

1000 items (flowable)
RxDogTagAndroidPerf.flowable1000_false                                             32,566ns   0.033ms
RxDogTagAndroidPerf.flowable1000_true_withoutGuardedDelegate                       51,765ns   0.052ms  58.95%
RxDogTagAndroidPerf.flowable1000_true                                             210,677ns   0.211ms  546.92%

1000000 items (observable)
RxDogTagAndroidPerf.observable1000000_false                                    26,984,534ns  26.985ms
RxDogTagAndroidPerf.observable1000000_true_withoutGuardedDelegate              34,621,670ns  34.622ms    28.30%
RxDogTagAndroidPerf.observable1000000_true                                    280,736,746ns  280.737ms   940.36%

1000000 items (flowable)
RxDogTagAndroidPerf.flowable1000000_false                                      29,811,097ns  29.811ms
RxDogTagAndroidPerf.flowable1000000_true_withoutGuardedDelegate                36,557,868ns  36.558ms    22.63%
RxDogTagAndroidPerf.flowable1000000_true                                      224,655,387ns  224.655ms   653.60%
```

Subscribe cost: grouped by complexity:

```
Simple (observable)
RxDogTagAndroidPerf.observable_false_subscribe_simple                                 148ns     0.000ms
RxDogTagAndroidPerf.observable_true_subscribe_simple_withoutGuardedDelegate        15,630ns     0.016ms  10460.81%
RxDogTagAndroidPerf.observable_true_subscribe_simple                               15,973ns     0.016ms  10692.57%

Simple (flowable)
RxDogTagAndroidPerf.flowable_false_subscribe_simple                                   198ns    0.000ms
RxDogTagAndroidPerf.flowable_true_subscribe_simple_withoutGuardedDelegate          15,881ns    0.016ms  7920.71%
RxDogTagAndroidPerf.flowable_true_subscribe_simple                                 15,895ns    0.016ms  7927.78%

Complex (observable)
RxDogTagAndroidPerf.observable_false_subscribe_complex                              5,331ns   0.005ms
RxDogTagAndroidPerf.observable_true_subscribe_complex                              22,095ns   0.022ms  314.46%
RxDogTagAndroidPerf.observable_true_subscribe_complex_withoutGuardedDelegate       23,033ns   0.023ms  332.06%

Complex (flowable)
RxDogTagAndroidPerf.flowable_true_subscribe_complex                                29,531ns   0.030ms
RxDogTagAndroidPerf.flowable_true_subscribe_complex_withoutGuardedCall             36,630ns   0.037ms  24.04%
RxDogTagAndroidPerf.flowable_false_subscribe_complex                               60,498ns   0.060ms  104.86%
```

E2E amortized cost:

```
Observable
RxDogTagAndroidPerf.observable_false_e2e                                          104,063ns  0.104ms
RxDogTagAndroidPerf.observable_true_e2e_withoutGuardedDelegate                    126,928ns  0.127ms  21.97%
RxDogTagAndroidPerf.observable_true_e2e                                           129,817ns  0.130ms  24.75%

Flowable
RxDogTagAndroidPerf.flowable_false_e2e                                            110,730ns  0.111ms
RxDogTagAndroidPerf.flowable_true_e2e_withoutGuardedDelegate                      152,865ns  0.153ms  38.05%
RxDogTagAndroidPerf.flowable_true_e2e                                             176,510ns  0.177ms  59.41%
```

 