### PR TITLE
Upgrade Dokka

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -23,7 +23,7 @@ def versions = [
     jmhLib: '1.21',
     jmhPlugin: '0.4.8',
     nullawayPlugin: '0.1',
-    dokka: '0.9.18',
+    dokka: '0.10.1',
     spotless: '3.27.2'
 ]
 

--- a/rxdogtag-autodispose/build.gradle
+++ b/rxdogtag-autodispose/build.gradle
@@ -31,15 +31,19 @@ dependencies {
 }
 
 dokka {
-  externalDocumentationLink {
-    url = new URL("http://reactivex.io/RxJava/3.x/javadoc/")
-  }
-
   // Output as Github flavored markdown so that docs show up inline in mkdocs website
   outputFormat = 'gfm'
   outputDirectory = "$rootDir/docs/2.x"
-  classpath = new ArrayList<File>(project.tasks['assemble'].outputs.files.files)
-  sourceDirs = files('src/main/java')
+
+  configuration {
+    classpath = [project.tasks['assemble'].outputs.files.files]
+    sourceRoot {
+      path = "src/main/java"
+    }
+    externalDocumentationLink {
+      url = new URL("http://reactivex.io/RxJava/3.x/javadoc/")
+    }
+  }
 }
 
 apply plugin: 'com.vanniktech.maven.publish'

--- a/rxdogtag/build.gradle
+++ b/rxdogtag/build.gradle
@@ -29,15 +29,20 @@ dependencies {
 }
 
 dokka {
-  externalDocumentationLink {
-    url = new URL("http://reactivex.io/RxJava/3.x/javadoc/")
-  }
-
   // Output as Github flavored markdown so that docs show up inline in mkdocs website
   outputFormat = 'gfm'
   outputDirectory = "$rootDir/docs/2.x"
-  classpath = new ArrayList<File>(project.tasks['assemble'].outputs.files.files)
-  sourceDirs = files('src/main/java')
+
+  configuration {
+    platform = "JVM"
+    classpath = [project.tasks['assemble'].outputs.files.files]
+    sourceRoot {
+      path = "src/main/java"
+    }
+    externalDocumentationLink {
+      url = new URL("http://reactivex.io/RxJava/3.x/javadoc/")
+    }
+  }
 }
 
 // We setup jmh such that you must provide the `-Pjmh` to specify which tests


### PR DESCRIPTION
An attempt at #61 but the newest upgrade doesn't have these fixes. 

This is basically happening where Java files are tried to converted to kdoc and constants like `STACK_ELEMENT_TRACE_HEADER` isn't converted correctly. 