### PR TITLE
Move credentials to env variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,8 @@ jobs:
     - name: Final checks
       run: ./gradlew check --stacktrace
     - name: Upload snapshot (master only)
-      run: ./gradlew uploadArchives -PSONATYPE_NEXUS_USERNAME=${{ secrets.SonatypeUsername }} -PSONATYPE_NEXUS_PASSWORD=${{ secrets.SonatypePassword }}
+      run: ./gradlew uploadArchives
+      env:
+        SONATYPE_NEXUS_USERNAME: ${{ secrets.SonatypeUsername }}
+        SONATYPE_NEXUS_PASSWORD: ${{ secrets.SonatypePassword }}
       if: success() && github.ref == 'refs/heads/master' && github.event_name != 'pull_request' && matrix.java_version == '1.8'


### PR DESCRIPTION
Passwords could contain special characters that could trip cli processes. GitHub Actions recommends using them as inputs/env variables https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets

Ref #63 