### PR TITLE
Update Proguard Rules for better R8 compatibility

### DIFF
--- a/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
+++ b/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
@@ -1,3 +1,10 @@
 # We keep these in order for DogTagObservers to properly work and resolve entries in each of these packages
--keeppackagenames rxdogtag2**
 -keeppackagenames io.reactivex.rxjava3**
+
+# R8 may inline subscribe() calls entirely to their call-sites, which breaks RxDogTag's tagging
+# While this is sort of a cardinal sin of libraries to do this, RxDogTag is only a few classes and 
+# incredibly small, so we claim this is a small price to pay.
+-keep class rxdogtag2.** { *; }
+-keepclassmembers class io.reactivex.rxjava3.** {
+  *** subscribe(...);
+}


### PR DESCRIPTION
Resolves #66. This is what we're using in our app and appear to have resolved our inlining issues. Suggestions welcome though on how to do something a bit more surgical with the keeps, unfortunately `dontoptimize` isn't allowed with a class matcher.

I'll separately do this for a 1.x release too.

<!--
Thank you for contributing to RxDogTag. Before pressing the "Create Pull Request" button, please consider the following points.
Feel free to remove any irrelevant parts that you know are not related to the issue.
Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
-->

<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
