### PR TITLE
Keep class names instead of package names in case repackageclasses is enabled

### DIFF
--- a/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
+++ b/rxdogtag/src/main/resources/META-INF/proguard/rxdogtag.pro
@@ -1,5 +1,5 @@
 # We keep these in order for DogTagObservers to properly work and resolve entries in each of these packages
--keeppackagenames io.reactivex.rxjava3**
+-keepnames class io.reactivex.rxjava3**
 
 # R8 may inline subscribe() calls entirely to their call-sites, which breaks RxDogTag's tagging
 # While this is sort of a cardinal sin of libraries to do this, RxDogTag is only a few classes and 


### PR DESCRIPTION
<!-- Please give a description about what and why you are contributing, even if it's trivial. -->
**Description**:
Use `keepnames class` rules instead of `keeppackagenames`, because `keeppackagenames` is not respected when `repackageclasses` is enabled.

<!-- Please include the issue list number(s) or other PR numbers in the description if you are contributing in response to those. -->
**Related issue(s)**:
https://github.com/uber/RxDogTag/issues/73

<!-- Please include a reasonable set of unit tests if you contribute new code or change an existing one. -->
